### PR TITLE
Feature/time to live

### DIFF
--- a/Droste.xcodeproj/project.pbxproj
+++ b/Droste.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		C6775D7B1F9B953A0004AE11 /* CacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6775D761F9B953A0004AE11 /* CacheFake.swift */; };
 		C6775D7C1F9B953A0004AE11 /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6775D771F9B953A0004AE11 /* DiskCacheTests.swift */; };
 		C6775D7D1F9B953A0004AE11 /* CompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6775D781F9B953A0004AE11 /* CompositionTests.swift */; };
+		C67DB6E01FD5F47D0033F5E4 /* Cache+Expire.swift in Sources */ = {isa = PBXBuildFile; fileRef = C67DB6DF1FD5F47D0033F5E4 /* Cache+Expire.swift */; };
 		C68A01EC1FA5F36B000DC341 /* Cache+Salient.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68A01EB1FA5F36B000DC341 /* Cache+Salient.swift */; };
 		C68EFD3A1FA73BBB00236C52 /* SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C68EFD391FA73BBB00236C52 /* SwitchTests.swift */; };
 		C6A4EC741F9B997900BD60DA /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = C6A4EC751F9B997900BD60DA /* RxSwift.framework */; settings = {ATTRIBUTES = (Required, ); }; };
@@ -87,6 +88,7 @@
 		C6775D761F9B953A0004AE11 /* CacheFake.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CacheFake.swift; sourceTree = "<group>"; };
 		C6775D771F9B953A0004AE11 /* DiskCacheTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
 		C6775D781F9B953A0004AE11 /* CompositionTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CompositionTests.swift; sourceTree = "<group>"; };
+		C67DB6DF1FD5F47D0033F5E4 /* Cache+Expire.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Cache+Expire.swift"; sourceTree = "<group>"; };
 		C68A01EB1FA5F36B000DC341 /* Cache+Salient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Cache+Salient.swift"; sourceTree = "<group>"; };
 		C68EFD391FA73BBB00236C52 /* SwitchTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SwitchTests.swift; sourceTree = "<group>"; };
 		C6A4EC731F9B995100BD60DA /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -164,6 +166,7 @@
 				C6775D6A1F9B94FD0004AE11 /* Fetchers */,
 				C6775D5F1F9B94E90004AE11 /* Caches */,
 				C6584C861FAA283500E50D0B /* Caches.swift */,
+				C67DB6DF1FD5F47D0033F5E4 /* Cache+Expire.swift */,
 				C6775D4A1F9B94CE0004AE11 /* Cache.swift */,
 				C6775D4F1F9B94CE0004AE11 /* Cache+Compose.swift */,
 				C6775D4D1F9B94CE0004AE11 /* Cache+ForwardRequest.swift */,
@@ -343,6 +346,7 @@
 				C6775D661F9B94F40004AE11 /* RamCache.swift in Sources */,
 				C6A4EC851F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m in Sources */,
 				C6775D5D1F9B94CF0004AE11 /* Cache+Compose.swift in Sources */,
+				C67DB6E01FD5F47D0033F5E4 /* Cache+Expire.swift in Sources */,
 				C6775D581F9B94CF0004AE11 /* Cache.swift in Sources */,
 				C6584C871FAA283500E50D0B /* Caches.swift in Sources */,
 				C68A01EC1FA5F36B000DC341 /* Cache+Salient.swift in Sources */,

--- a/Droste.xcodeproj/project.pbxproj
+++ b/Droste.xcodeproj/project.pbxproj
@@ -42,6 +42,8 @@
 		C6A4EC841F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A4EC821F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.h */; };
 		C6A4EC851F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A4EC831F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m */; };
 		C6A4EC9A1F9BA7E300BD60DA /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A4EC821F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.h */; };
+		C6E8538F1FDC6BFD0060442B /* ExpireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */; };
+		C6E853911FDC71380060442B /* ExpirableCacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E853901FDC71380060442B /* ExpirableCacheFake.swift */; };
 		C6FAD4D91F9BACC30057A9B6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6775D471F9B94CE0004AE11 /* Extensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -97,6 +99,8 @@
 		C6A4EC821F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = "NSKeyedUnarchiver+Swift.h"; sourceTree = "<group>"; };
 		C6A4EC831F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+Swift.m"; sourceTree = "<group>"; };
 		C6A4EC9C1F9BA93400BD60DA /* RxSwift-umbrella.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "RxSwift-umbrella.h"; path = "Example/Pods/Target Support Files/RxSwift/RxSwift-umbrella.h"; sourceTree = "<group>"; };
+		C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpireTests.swift; sourceTree = "<group>"; };
+		C6E853901FDC71380060442B /* ExpirableCacheFake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirableCacheFake.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -155,6 +159,8 @@
 				C60352351FA6107200C23D82 /* MapTests.swift */,
 				C68EFD391FA73BBB00236C52 /* SwitchTests.swift */,
 				C6584C821FAA199000E50D0B /* RamCacheTests.swift */,
+				C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */,
+				C6E853901FDC71380060442B /* ExpirableCacheFake.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -345,6 +351,7 @@
 				C6775D561F9B94CF0004AE11 /* Cache+Map.swift in Sources */,
 				C6775D661F9B94F40004AE11 /* RamCache.swift in Sources */,
 				C6A4EC851F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m in Sources */,
+				C6E8538F1FDC6BFD0060442B /* ExpireTests.swift in Sources */,
 				C6775D5D1F9B94CF0004AE11 /* Cache+Compose.swift in Sources */,
 				C67DB6E01FD5F47D0033F5E4 /* Cache+Expire.swift in Sources */,
 				C6775D581F9B94CF0004AE11 /* Cache.swift in Sources */,
@@ -356,6 +363,7 @@
 				C6775D681F9B94F40004AE11 /* DiskCache.swift in Sources */,
 				C6775D571F9B94CF0004AE11 /* CompositeCache.swift in Sources */,
 				C6775D521F9B94CF0004AE11 /* Cache+SkipWhile.swift in Sources */,
+				C6E853911FDC71380060442B /* ExpirableCacheFake.swift in Sources */,
 				C6775D531F9B94CF0004AE11 /* Cache+Switch.swift in Sources */,
 				C6775D5B1F9B94CF0004AE11 /* Cache+ForwardRequest.swift in Sources */,
 				C6A4EC811F9B9E9300BD60DA /* ConcurrentDictionary.swift in Sources */,

--- a/Droste.xcodeproj/project.pbxproj
+++ b/Droste.xcodeproj/project.pbxproj
@@ -43,7 +43,6 @@
 		C6A4EC851F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = C6A4EC831F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m */; };
 		C6A4EC9A1F9BA7E300BD60DA /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = C6A4EC821F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.h */; };
 		C6E8538F1FDC6BFD0060442B /* ExpireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */; };
-		C6E853911FDC71380060442B /* ExpirableCacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6E853901FDC71380060442B /* ExpirableCacheFake.swift */; };
 		C6FAD4D91F9BACC30057A9B6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = C6775D471F9B94CE0004AE11 /* Extensions.swift */; };
 /* End PBXBuildFile section */
 
@@ -100,7 +99,6 @@
 		C6A4EC831F9B9EEA00BD60DA /* NSKeyedUnarchiver+Swift.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = "NSKeyedUnarchiver+Swift.m"; sourceTree = "<group>"; };
 		C6A4EC9C1F9BA93400BD60DA /* RxSwift-umbrella.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; name = "RxSwift-umbrella.h"; path = "Example/Pods/Target Support Files/RxSwift/RxSwift-umbrella.h"; sourceTree = "<group>"; };
 		C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpireTests.swift; sourceTree = "<group>"; };
-		C6E853901FDC71380060442B /* ExpirableCacheFake.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ExpirableCacheFake.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -160,7 +158,6 @@
 				C68EFD391FA73BBB00236C52 /* SwitchTests.swift */,
 				C6584C821FAA199000E50D0B /* RamCacheTests.swift */,
 				C6E8538E1FDC6BFD0060442B /* ExpireTests.swift */,
-				C6E853901FDC71380060442B /* ExpirableCacheFake.swift */,
 			);
 			path = Tests;
 			sourceTree = "<group>";
@@ -363,7 +360,6 @@
 				C6775D681F9B94F40004AE11 /* DiskCache.swift in Sources */,
 				C6775D571F9B94CF0004AE11 /* CompositeCache.swift in Sources */,
 				C6775D521F9B94CF0004AE11 /* Cache+SkipWhile.swift in Sources */,
-				C6E853911FDC71380060442B /* ExpirableCacheFake.swift in Sources */,
 				C6775D531F9B94CF0004AE11 /* Cache+Switch.swift in Sources */,
 				C6775D5B1F9B94CF0004AE11 /* Cache+ForwardRequest.swift in Sources */,
 				C6A4EC811F9B9E9300BD60DA /* ConcurrentDictionary.swift in Sources */,

--- a/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/Example/Example/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -39,6 +39,11 @@
       "idiom" : "iphone",
       "size" : "60x60",
       "scale" : "3x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -25,7 +25,8 @@ class ViewController: UIViewController {
         
         let diskCache = DiskCache<URL, NSData>()
         let ramCache = RamCache<URL, NSData>()
-        let dataCache = ramCache + (diskCache.expires(at: .seconds(10)) + networkFetcher).reuseInFlight()
+        
+        let dataCache = ramCache + (diskCache.expires(at: .seconds(60)) + networkFetcher).reuseInFlight()
         
         let imageCache = dataCache
             .mapValues(
@@ -35,11 +36,7 @@ class ViewController: UIViewController {
                 return (UIImagePNGRepresentation(image) as NSData?)!
         }
         
-        
-//        let imageCache = DrosteCaches.sharedImageCache
-
         imageCache
-//            .expires(at: .seconds(10))
             .get(URL(string: "https://dars.io/wp-content/uploads/2015/06/1435934506-50d83ee90498b3e4f9578a58ff8b5880.png")!)
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: {[weak self] (image) in

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -23,12 +23,10 @@ class ViewController: UIViewController {
                 return URLRequest(url: url)
         }
         
-        let diskCache = DiskCache<URL, NSData>()
-        let ramCache = RamCache<URL, NSData>()
+        let ramCache = RamCache<URL, NSData>().expires(at: .seconds(30))
+        let diskCache = DiskCache<URL, NSData>().expires(at: .seconds(120))
         
-        let dataCache =
-            ramCache.expires(at: .seconds(30)) +
-            (diskCache.expires(at: .seconds(120)) + networkFetcher).reuseInFlight()
+        let dataCache = ramCache + (diskCache + networkFetcher).reuseInFlight()
         
         let imageCache = dataCache
             .mapValues(

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -20,6 +20,7 @@ class ViewController: UIViewController {
         let imageCache = DrosteCaches.sharedImageCache
         
         imageCache
+            .expires(at: .seconds(10))
             .get(URL(string: "https://dars.io/wp-content/uploads/2015/06/1435934506-50d83ee90498b3e4f9578a58ff8b5880.png")!)
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: {[weak self] (image) in

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController {
         let diskCache = DiskCache<URL, NSData>()
         let ramCache = RamCache<URL, NSData>()
         
-        let dataCache = ramCache + (diskCache.expires(at: .never) + networkFetcher).reuseInFlight()
+        let dataCache = ramCache + (diskCache.expires(at: .seconds(60)) + networkFetcher).reuseInFlight()
         
         let imageCache = dataCache
             .mapValues(

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -17,10 +17,29 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         
-        let imageCache = DrosteCaches.sharedImageCache
         
+        let networkFetcher = NetworkFetcher()
+            .mapKeys { (url: URL) -> URLRequest in//map url to urlrequest
+                return URLRequest(url: url)
+        }
+        
+        let diskCache = DiskCache<URL, NSData>()
+        let ramCache = RamCache<URL, NSData>()
+        let dataCache = ramCache + (diskCache.expires(at: .seconds(10)) + networkFetcher).reuseInFlight()
+        
+        let imageCache = dataCache
+            .mapValues(
+                f: { (data) -> UIImage in
+                    return UIImage(data: data as Data)!
+            }) { (image) -> NSData in
+                return (UIImagePNGRepresentation(image) as NSData?)!
+        }
+        
+        
+//        let imageCache = DrosteCaches.sharedImageCache
+
         imageCache
-            .expires(at: .seconds(10))
+//            .expires(at: .seconds(10))
             .get(URL(string: "https://dars.io/wp-content/uploads/2015/06/1435934506-50d83ee90498b3e4f9578a58ff8b5880.png")!)
             .observeOn(MainScheduler.instance)
             .subscribe(onNext: {[weak self] (image) in

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -26,7 +26,9 @@ class ViewController: UIViewController {
         let diskCache = DiskCache<URL, NSData>()
         let ramCache = RamCache<URL, NSData>()
         
-        let dataCache = ramCache + (diskCache.expires(at: .seconds(60)) + networkFetcher).reuseInFlight()
+        let dataCache =
+            ramCache.expires(at: .seconds(30)) +
+            (diskCache.expires(at: .seconds(120)) + networkFetcher).reuseInFlight()
         
         let imageCache = dataCache
             .mapValues(

--- a/Example/Example/ViewController.swift
+++ b/Example/Example/ViewController.swift
@@ -26,7 +26,7 @@ class ViewController: UIViewController {
         let diskCache = DiskCache<URL, NSData>()
         let ramCache = RamCache<URL, NSData>()
         
-        let dataCache = ramCache + (diskCache.expires(at: .seconds(60)) + networkFetcher).reuseInFlight()
+        let dataCache = ramCache + (diskCache.expires(at: .never) + networkFetcher).reuseInFlight()
         
         let imageCache = dataCache
             .mapValues(

--- a/Example/Playground.playground/Contents.swift
+++ b/Example/Playground.playground/Contents.swift
@@ -22,7 +22,7 @@ _ = testCache.get(key).subscribe(onNext: { (value: String) in
 })
 
 DrosteCaches
-    .sharedImageCache
+    .imageCache(expires: .seconds(10))
     .get(URL(string: "https://dars.io/wp-content/uploads/2015/06/1435934506-50d83ee90498b3e4f9578a58ff8b5880.png")!)
     .observeOn(MainScheduler.instance)
     .subscribe(onNext: {(image) in

--- a/Example/Playground.playground/Contents.swift
+++ b/Example/Playground.playground/Contents.swift
@@ -39,3 +39,8 @@ DrosteCaches
         let object = jsonObject
     })
 
+let date = Date()
+let date2 = date.addingTimeInterval(10)
+
+let diff = date2.timeIntervalSince1970 - date.timeIntervalSince1970
+

--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Droste (0.1.0):
+  - Droste (0.1.1):
     - RxSwift
-  - Droste/Tests (0.1.0):
+  - Droste/Tests (0.1.1):
     - Nimble
     - Quick
     - RxSwift
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Droste: 574047778259b6177d5d0129f1de7ac15927a506
+  Droste: 03a81fe20f2e5c323f2288c577e0c844803e1998
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334

--- a/Example/Pods/Local Podspecs/Droste.podspec.json
+++ b/Example/Pods/Local Podspecs/Droste.podspec.json
@@ -1,6 +1,6 @@
 {
   "name": "Droste",
-  "version": "0.1.0",
+  "version": "0.1.1",
   "summary": "Droste is a lightweight composable caching library which leverages RxSwift's Observable for its API.",
   "homepage": "https://github.com/gtsifrikas/Droste",
   "license": {
@@ -12,7 +12,7 @@
   },
   "source": {
     "git": "https://github.com/gtsifrikas/Droste.git",
-    "tag": "0.1.0"
+    "tag": "0.1.1"
   },
   "social_media_url": "https://twitter.com/gtsifrikas",
   "platforms": {

--- a/Example/Pods/Manifest.lock
+++ b/Example/Pods/Manifest.lock
@@ -1,7 +1,7 @@
 PODS:
-  - Droste (0.1.0):
+  - Droste (0.1.1):
     - RxSwift
-  - Droste/Tests (0.1.0):
+  - Droste/Tests (0.1.1):
     - Nimble
     - Quick
     - RxSwift
@@ -21,7 +21,7 @@ EXTERNAL SOURCES:
     :path: ../
 
 SPEC CHECKSUMS:
-  Droste: 574047778259b6177d5d0129f1de7ac15927a506
+  Droste: 03a81fe20f2e5c323f2288c577e0c844803e1998
   Nimble: 7f5a9c447a33002645a071bddafbfb24ea70e0ac
   Quick: 58d203b1c5e27fff7229c4c1ae445ad7069a7a08
   RxSwift: fd680d75283beb5e2559486f3c0ff852f0d35334

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,334 +7,335 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
-		018556E238B9E73188305B13DFE0308B /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C64788EFA087B5960001B6155C636A8 /* WithLatestFrom.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0173A4EEDD0605B7E9E47B073C11386E /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73030AA83660A13E569AD0113EEB8D17 /* SubjectType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0194CB2DDD4E3A73B842A3DAE51A1614 /* NSKeyedUnarchiver+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = 8149C0BA1CCDF2D145E8FAA861C9F9F7 /* NSKeyedUnarchiver+Swift.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		02533B9F7F4CE9CD179E1F1E0E774F8A /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E71AEC51B010BB3D5AB352ACFBB17BE /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		03324D909AAD2631F09516516E6FAFF9 /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EE71F0FE105E79407BC049D2A38772 /* ConnectableObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		03188CDAFFD40BD101B4A8FB4D414B23 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A3F3BF839B9897E261ED3E39FE2649 /* ScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0338B975146864D901AA5E770DE5FD12 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE2CE670FF86727A412F5593CDD2A9E /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		037248D2F976E6C7AC3AC472274033CD /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C254261A9FC83104DF1D24C33F31110 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0549D038F1D25A4F25A6BA9FDCA3B140 /* First.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BA10C614BE6C945F2AF6EFD8CD6FDF /* First.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		03D7ABEEB3F5CAD02C5EF483A0C824AC /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814356EE1E9605CC4A9AC25448622168 /* OperationQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		04C241623428C470EC9A647F5CCAFF18 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		05ADC41A172933377F6606E2E513AC6E /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = AF17E0B9D2E8682E672520F4CCA1E0C4 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		062C572892FC95269637D9E6F07AB644 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075EB582A63C32140E7D9741CF677CA4 /* Enumerated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		06AE843EE537E5C65FC24B0BEABAE323 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20112E2D057B83282A63E76E8FA565D /* SingleAssignmentDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		079A50DE3F6FD0314754611A959C6834 /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A1FD49CBC095971BF93E61BB94883D /* MainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		08196B9695D5E43B036B5D9DA0255D7B /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF14725542D87B58BC2E9CEFE8368AA5 /* Sink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		05D3F1FD31EAAA792E3B1DC37661D923 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647E651ED7B69A270E297A1E2E9976BC /* SchedulerServices+Emulation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		061944FF69F1D7ED5E459B5E02F5EBB3 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56DA18B320AAC1740C443786FDBB024 /* SwiftSupport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0822659E8C3D41902B196E44C8AA9DC0 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605139D9F86CB74500BF0C1D13A2484B /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0899DBA1BA66BF451A8A9D31FA682A7F /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537A211511A8B2175890320C5F6414D8 /* Timeout.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		08B139B94CC2319B08F8CEA90275697E /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808B09CF83EB3F57ABF9F7E375B8057 /* AnyObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		08BB725639DE88D7F64BC84F3CF1AFA1 /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A853DBF6D21EC875FD8AD8B1F1EE71 /* Sequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		08EDDF54E6AAF16AEA5D116786EB9D70 /* RxTest-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 810BCE23B1C947B337E42F6080A31924 /* RxTest-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		08EF70BB8DA11248DE6AB0D30C443BCA /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F760993273BAFD1F853A8923273368A /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0AB4790C253E0AB1650CC1898FCC2021 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C823EEE007452668D8D018D5A5EC0 /* Throttle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0C19AF878C5A3E578B8B887F4AFEDA7E /* Normalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B1DBBB94EFF1F9CD0DF61DB6468C52 /* Normalize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		09275FC7C7D330423761A5971735A452 /* Cache+Salient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78517930A474EF59907D69BBFFC104 /* Cache+Salient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		095331F60096F4DCE71960DFFD33935A /* Droste.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FE02D88F98AE2E31C5E483D3AD5E674 /* Droste.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		0CAD7AAF511C7091B684129E05F8E390 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4916EB8BE4199D7627C169F2CA6B91 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0D223A33663A0C7B8E9389D375AD8613 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AE8D9AB2CF3C93E0C153DEDA2F0AD11 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0E8572AE94BAB3BEF73F4EB7896C4135 /* Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780C8A5F17502180FDB54824FD3F810D /* Create.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0FA3681734FA50C3FF4CA05F5B736CC5 /* Zip+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA1890ABEC35BB449F3F5683C6B2425 /* Zip+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		104C862C26CF08775C3569158DBA32E2 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EEBC6B47328C37B6BC71434FF08C52B /* VirtualTimeScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0F52A5B16943C5852CECD827A344BD95 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F9554E85E94DB66EDF8F5964EDC0C /* Scan.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0FA73ABD6671F5A64236EF3DE6FAAC85 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28754340AEF03EB84EA98ADFDCF1EE5F /* Empty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		10F5D42D18FA365F6D5C3D201485CF16 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0549EB263233A4E143B87A2CB6B7DDED /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1154CD7D9A18BA187BD62F9AC2E22A5B /* ObservableType+PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108EFBCF28406ECBB643D5EC949493CF /* ObservableType+PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		11659C99869BEA89EBBB3B8900843C1F /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A1FD49CBC095971BF93E61BB94883D /* MainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1274B134CE9040B1449216A96010862D /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2CDFAEC61EFDD038EE89B7310CBAD /* StartWith.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		136A3089581C6972224CBB3E322C33D5 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EEBC6B47328C37B6BC71434FF08C52B /* VirtualTimeScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		13C199C1B90124DAF09DC5FB4866E02A /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EE71F0FE105E79407BC049D2A38772 /* ConnectableObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		147D72F263555017EFF3DDE13471D15B /* SwitchIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0424E1790219422B7EB6B251ED7429B0 /* SwitchIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		159D66FF8F1B2C3D4EA217B4C19AD73D /* Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95332C62694E7BDC87A33226B19B43C5 /* Reactive.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		15B10C41A64E1F8A43A6D2826A55EF37 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCAF829B1C8D3DA675E0C02B226EF70 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		15DFAD42206FA56569E2C90ED08119D5 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E74A6E007520ECCE695064780621BC4 /* String+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		1687FAE4E4C13F98300A1598C8E2F021 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78833EBBC71D330C71218DBAAA1A4B9 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		177C926198AABA019627F8C5980B7954 /* RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D60A169920697B20C2D24FB59E5AD6E /* RxSwift-dummy.m */; };
+		1769644B70D4B44752D87F64B7118673 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A6A90586B5D6FF6007D3A8CAE078A /* Generate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		17D7DE0B2CCB42E91FA9F5A814627E4E /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 185AF272F0B6DA8C8F9441D231093075 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		192C604745F0C0A389CAFC6CE8622170 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A3F3BF839B9897E261ED3E39FE2649 /* ScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		19781E48735064957D4102750EAF5B19 /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFACB25ABE7EF55F68113515C4ED284 /* NopDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1B00991A7B42C3947404F6D05BC4A72B /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6842D0BDC309FDCB3C54B56A18F7BB /* SkipUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1C123C04FA1B7C35E1B2C810FB3E90C8 /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F88EB886E9B11A3ACE686A7DE97749 /* SynchronizedOnType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1CB32BFBEC07E91745CBD6B4BB601736 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616271A38C3EEDFCB5D35828D794B2F /* Disposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1EC7B737F053FEE4BFA8F779C828A934 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8771C43A89854E33143BC1E490E982F /* Reduce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A2C1F5126659B385FACC1F8C359962F /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD067F7995E2B5EBCF8D7991F6C0001D /* Lock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1F05D1A8B2EEBC878BEB45E7324C2251 /* RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D60A169920697B20C2D24FB59E5AD6E /* RxSwift-dummy.m */; };
 		1F66D9DC2277C1493303E986C77D2152 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9761F27F54E78828A2B807DAB2A25879 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1FD90C9AFE89C26BA26F6DB48A889D74 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4AD59559CE5395612189B0ABF91761 /* ObserveOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1FDC8938CFA792381A76A0EE3EB198E4 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0881E653DB56735064FFE28E4C372564 /* InvocableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		20BBD8E5464B6A90F85438A06AE2E814 /* SwitchIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0424E1790219422B7EB6B251ED7429B0 /* SwitchIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		211152C91CAFAA59B1D967241EAC7027 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BB400C567E6BEB87A66592000A7F8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		213FC97651D608E8761A2FB58479ADC3 /* RetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB49F887C65A84BCD16B9793D9071986 /* RetainTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2219DF8604BDD04E1BF575D5C049E4E1 /* Cache+Compose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 833DA1A8D2C771CFE16B3550AE6BE063 /* Cache+Compose.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		213FC97651D608E8761A2FB58479ADC3 /* RetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		22A35B5A639A852513DB1C741CFCA826 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0F4EE119E65A2790A5BEE531ED8E21 /* SchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		23C7AA4804BAE5923E216C317F3C6774 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64299BE07801777F3AD2B98E369C01A5 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		24E0E6E24A1712F5379A2E76B6CE1F88 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AEBCEC65280E1F273BF5299035E47 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25052BA59B65807D88203BE1A14503C4 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58E0F0B1A3B6F28663FC08EB3ACDE78 /* Repeat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25482E29D157C0980980474F2BAE0F18 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65B7F488687567D2AD4AEB111AAB8BA /* Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25A5FF071D6A9C1712E9865086ED70B6 /* Bag+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB2550B5110CA4FB9C6FD26836A6EBC /* Bag+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25D1782C4EB5D0D78292908DC8341E43 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE18E0BFD2918C0E3F1B5AB26CA5D95F /* Take.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		25EF3B3A5930CFFD54C90857C839673B /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6842D0BDC309FDCB3C54B56A18F7BB /* SkipUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		267C95483B8179811B8A0DD88D5BEDD9 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 935B7F52803202DC339031D5E9057028 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		27FC89ECC2417B07D6CD80B9A48BF277 /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFBAE0B2D0F4EDF8D893E80BFB1AE0 /* Using.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		296019E670AEBDCD622CF9060226C268 /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D122B4BB2E236A54975BD2A0227F3A /* Range.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		275723D3C6210BA56183816D9559C802 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9677E9E790094792357AB00A80B5F99 /* Deferred.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		27703FE37EE62F7CCCF99503C980AB87 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F239EF1F6D92241D56ABA8E4C73B440 /* Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		277BA07071FDEEDC5D4C2620538F5B79 /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AE06D808F2F25DAA9F9ACDF64372B7 /* Materialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2788CC3E2DE956D85DDBABA95B85F732 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825C5C72FF462971F73D71DB1F4B853 /* Completable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		27CB886DA24010A0EC45C21FD4A584CF /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B9AC2AE3E5160F770D7E24A360B21 /* AnonymousObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		294E6969BC1CF557346E9BD651F43F08 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808B09CF83EB3F57ABF9F7E375B8057 /* AnyObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		29B90D6FCCB3F006EF87FBFA89E21988 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4F446ADE478C1C1E01A6DF2EAD0BEE /* Amb.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2B581E08B43374A783FE338A9CFC96BE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDE67C898D6218C71BCA27B4970A5A1 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2BF11EB9D40BD97A04E61193B8975554 /* Cache+Compose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E8BD9801D9F2445DF683A261C21ABA /* Cache+Compose.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2C8F0DBC6229BEFB4288C1E2ACF9C082 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF68BE3CB6608B515CE233AD8231A2 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2CA018ECB6506E746F2EFBAD279B2100 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075EB582A63C32140E7D9741CF677CA4 /* Enumerated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2D662B9A68C43FBF41CF2F4623629EE7 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C162ADAA8658A02659DCAC1E8364D596 /* ConcurrentDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2D937BB1FDCBE087EDB04584FC0D040C /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF14725542D87B58BC2E9CEFE8368AA5 /* Sink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2DD307F1CD8D3C1143C764EF397C641A /* HotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E953C4F03F79DF6469B6ABFF6AF88345 /* HotObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2E1AD718C49F0FCAFB24BAB1A2F38A5F /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0D12CD7CA4FA31C47EA57756F53C78 /* DisposeBag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2ECB31673D74715153B0A9C288D91E32 /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6B103DE3F9F97F83E6C476C1B16C5 /* Skip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2F84D22F90A6E783B5B0528C02AAE4E8 /* GroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D993FEFA0466F8C553B6AAF5A4F255F /* GroupBy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		316749FD439F948A52326344A4198EB4 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0881E653DB56735064FFE28E4C372564 /* InvocableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		321CB0B147B3E5A0D52B1F813265C99A /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6B103DE3F9F97F83E6C476C1B16C5 /* Skip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		33139A81336AC126C8A40954143CA1B2 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC43508F7BCF0D0844BC4CB3969BE63 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		332F326CC09BFB2893BB6F8BB34F6A8E /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABE976D29E82D47711F15A1E106E8B /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		335A4D1631C8F841383004FB6B9D9CC0 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56DA18B320AAC1740C443786FDBB024 /* SwiftSupport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		33CBE40C7924C67E4548605D8ABB4356 /* RxSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 586FC161DF179CF64CFFD5DBA3E8AA7F /* RxSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		33F7A5BF76F0D64CCC8F058943572F4D /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F546642C51F69052520612EAA9986664 /* DistinctUntilChanged.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3419A58633B56E6BA25032332DB40015 /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = D220738394C885CAE465F0CC85974514 /* Window.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		34B5AD045CA98D267E7E9F34D2A5F684 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29623F1E75DD8832C602FF1FA3FF98 /* SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		34C6E92749ED85A4800601FE8DB66156 /* Caches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 37379A91DE98AFA5A17EC9C5EEAD98CE /* Caches.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		34D7852543CAA5550D357F3942F490AC /* TestableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B62E0023CFA5E49361FBA265A510BF3 /* TestableObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		34FF11A9E918D299FC5C448C132C8881 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DF150BFE695968F04236FFF189878F /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		354033E6429C35730A350582C22A65AB /* Pods-Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 699118D7DDD5F335E4FB8B17DC0F12D2 /* Pods-Example-dummy.m */; };
 		35E3FA5431060710A7FECBE30D97763D /* CurrentTestCaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 427A864D7DB8FDF816621B3A36D25152 /* CurrentTestCaseTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		364515488BACFF39184BA19D0D51715A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AB571F432C9F57179967B6111A329D8 /* MapTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		364515488BACFF39184BA19D0D51715A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		36A2373F2EB063A0FFE26862A7DF2367 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EA88F354299C8AB82E10AED0726677 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		36CB65BF1273A7BCAC149538E75DB249 /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9FA296A61F02C71E067B65E060AF9A /* ObservableConvertibleType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3724AEA33A5FED8D21001F5BE45206AE /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3DD92AFC2E510C7B449FED87EDCE01 /* BehaviorSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		374DBC00BF9FEDD8B49906A0B58047F4 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 09ED5D24C2B42766C425AE76FACDD05C /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		3767D1B81F29435BE1E897E3BE982563 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8328E7C0D6403714ECE7338CC9440073 /* CompositeDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3778B5D8CC22864E8BE2D23D1C215F60 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC2626B8358940692B134A160E14C32 /* Cancelable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		37B9F41B358AAFFC676590924B0E191B /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A35FBA742FC0639CB1C60CA73765C85 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		384AC1469BB3C99889312CDFF0D3A4A4 /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA885A063120E9224890A1BDF6C0E8B9 /* DelaySubscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		388964141715E092BE47496FA0472362 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F54A3B30611A47020ECCDA28872E892 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3AB9EF6AF3C144719170FD525495D371 /* Droste.h in Headers */ = {isa = PBXBuildFile; fileRef = FCC0A3CEAEA336CFBF57500DC81615E9 /* Droste.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		3AD7FCD8C56B34C08175CFE1914BE3D1 /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2CDFAEC61EFDD038EE89B7310CBAD /* StartWith.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3B0FDBC1D1913D386F4B530D5BE27551 /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B189A16C05A14C69624B1D23DEAB3C /* AsyncLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3BB21D2D64998A64929CB1914BAD003B /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C452554BDE351A5CEB8E24DCFB934D /* HistoricalScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3C40E5C8B360F1F81100630D5B3B5101 /* ObservableType+PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108EFBCF28406ECBB643D5EC949493CF /* ObservableType+PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3C4477167645153A119029EB55437871 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A93D8653FA5EF9411A69B18AB621F /* Never.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3D3CFC9B67AA72BC58C7FF20E3546E3E /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50638A0FFF40CE3653E500FAB7819CF /* ToArray.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3D46E00C07A49E4E1A6DADF32F182C5F /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF8963A749934021EE631E46FA8D10 /* Debounce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3E5F7F47A7092E1944CF1CD29EFD51F5 /* SalientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F80DAB2FE925D417E88FD10BF200CAD5 /* SalientTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		380E1207677373B78A069BFB82D93BEF /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90117FABAAFBA5499FEFE1ADD97272AC /* Zip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		39E920086BAA939E51EF706063032F74 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14688EEE13E18098791B2E48FF192795 /* RetryWhen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3B33D8F76BE5569B0CB062DE7640D4B8 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE726664E88FA4A800280396E6EBE7CA /* Disposables.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3C5CE03ABE42D285736FEF12FC9A65E6 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA7D068830C8E38B73913ABA551D6AA /* TakeLast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3E5F7F47A7092E1944CF1CD29EFD51F5 /* SalientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3F131EB45A58205368E66823F52EC878 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EEAFCA4A8E32343B7D61B76A6405D /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		40F064F9753E41EB1F13609E650ED8AF /* PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599A56FB0BD0A419A50451DADC8E2D60 /* PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		40FB69139987D5CAFC639BBB8E08A8D9 /* AsyncSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8BF1B97667C167D9815FDD505BF522 /* AsyncSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		423689DBD345F053476DD6F19D3C92D0 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4F446ADE478C1C1E01A6DF2EAD0BEE /* Amb.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		429B952FB5B9DB060690D0DD499A1DE2 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647E651ED7B69A270E297A1E2E9976BC /* SchedulerServices+Emulation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		41466042D0214DA5DE79F26B0FBA2982 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29623F1E75DD8832C602FF1FA3FF98 /* SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4258AA593C9CCE33629ADBFA96526317 /* AsSingle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2F7551F3ABE331C18F6C0D2BF5001F /* AsSingle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		42A447EDEA9D4513DC3C329D3635F305 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F869E070B98513E85F2F7921AEAC /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4397BF2D949A88D04E768F33E36FB14D /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9535482AAB6042AA7B9F4708C95A8F1 /* BinaryDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4406995930AF3FB0D79EA917A1D0CDBE /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02932E0F16695277F04D1B0CA7FA2C2 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		44C8ADB25DDB31DCAB38EF9C4EE2BC88 /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = 9254FA8F7F484E8D845D36DB05B6AB73 /* NSKeyedUnarchiver+Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		4538AAC730F9D848CB2B0DDA48AF1E22 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780A534B38DE71C0A2986E58F56EF23 /* AnonymousDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		431D97078DC63A8C62CB03F084A6E3DE /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FF73BA6D2BE9A0DD6E2B7FB04382EF /* ScheduledItemType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4338ACDD18BF99A590DD48619B1AAA42 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDF9BFF6F914D4F8E12C8E5F85922F9 /* Timer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		435D113F94FB89E096EF59C9C43A5FA0 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3517B45D9C3D29D33E054064596EC37D /* Sample.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4597E5BF849E6709638CCCCA28D51F4E /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AA58C96DBD798CAE5DFC169065D36EB /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		45A507E8E58BC6414049A9267578D9FB /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F4C9B8DEFAA1296AC1C58825EA5FBA /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		46E14A903045717CA9B8963F408638F4 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7D715D5363605B3D84F701394CA127 /* Event.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		476CE51CFE374CC103E02D5109D97D4B /* CompositeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 19931B0C3BEFF5E9ED997DD64BC3F996 /* CompositeCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		49DBF5631CCE670375126A5EEE8D922E /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC23D858B2A515A23808022D5F2DD7D7 /* Just.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		45F683DAD98913377CB85EFF6EC4F914 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20112E2D057B83282A63E76E8FA565D /* SingleAssignmentDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		461D85757088B19B697B15FDBC06A648 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
+		4764374BC93274D75EA6FDDB269B4309 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456AA1151E2EB02F7FE37EBBFE64EBA0 /* HistoricalSchedulerTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4769D5B34FFE8805959C1F0A694F1337 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A93D8653FA5EF9411A69B18AB621F /* Never.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		47AF15CFD9AAD74FB5AF01DD8536F920 /* AsMaybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F96F3E7E0E183E02B71545016D7559 /* AsMaybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		47C46114C297B26B7E6872051D095CF1 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4CCF58DC99E09361656CDEB3F969AB /* Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4A0774063C4895027EDC5542CF7995EE /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
-		4A72FD8305588AE73A35CA46DD6F15C2 /* PrimitiveSequence+Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36C37D0620E19DE982B14EE97CB492D /* PrimitiveSequence+Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4C485FDA68C8C13A051687951DBBA7D2 /* CompositeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCEEF36C09885B713A3D7560E100904 /* CompositeCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4C5BB237628BDD6B0FB3143E58CB0FF4 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28089142BAB02F317AD1CA3C743F4161 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4C6BFBEFE87A84B6E23FB0DAEC2F0936 /* AsSingle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2F7551F3ABE331C18F6C0D2BF5001F /* AsSingle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4C8371EE4E418D8783350642CDDDBCF9 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E67A0D7B7413977E91583D48768D24B /* Cache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4D472FBA13EE73EB46A7740DEC941A60 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8670ADBA31F83F75BA94F9ABA974F3 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4D80D9E6AFD7C9745D7FD55AEE345317 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8565A00AAA29127E3A316E9921DBE732 /* RxTest.framework */; };
-		4DB056FDF08265D454BAA1226B9BF3D5 /* GroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D993FEFA0466F8C553B6AAF5A4F255F /* GroupBy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4E2954EFC7CA603552B4E728302B50D8 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E47B5D388A4DD83CAB93471D121A92 /* CurrentThreadScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4E43B22EB39D579A360E8AB2EB54EC1F /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EDA30233CDB9F471E3F31C8B71EB /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4EFE4AF4B998C54ED2CFF742F436F8BD /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BCCE1CBFDAB8CE24C44B3C3FECFA4E /* ElementAt.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5010E8CC1A303CF680DB04A7F6FD8599 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBB5EB74E0D9C84930C7438F7640E03 /* Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5023D249C03A75C6E8B18800A0DDDE0C /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E11AB03A3F11B7AFB7A0D0F19A0B3 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		512D468741ACC105E4F5B0683EA30FF9 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8808EAB77FFB53FD5AE82864839F82 /* Buffer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		515C61278B15FA564587EF581B9B8655 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DAE05351EC6B959EBA64BAF862395F /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		51B119C5686545183621B7B51516BB3A /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374A0DAFD6D8FF7495CEBC805719A79A /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		51C649D1B46B04259DFCB5A40FA23008 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8A6753BE6CC5702F03A94774613D01 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		535B724C0A1EECF6067F755D533DCB9B /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4250907D10CED5894873CB05B98773 /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		527A3DD5CF1560E5CBFB9D2AB223DB27 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C4436206C8A0E350BABC0165A4DFEE /* Observable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		53892A7B91F7D479A1533E8774CB60A9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		54D134BAEC188454E17A48D19470B525 /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE2787BAD6CAB49C44AC814A83A2ED6 /* SynchronizedDisposeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		53BF9ADEE0A4CBFB006DE21BF9E7DDF3 /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD223D6831D0AC58EDFA33069A37F497 /* Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		554D0D04E88910C81E0DDAD3F6A55C5B /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E96538CB79CC8AF348E3364422431F4 /* ScheduledDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		55BDC9F52B051264E39CFBAD34C54C26 /* Cache+ForwardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15ADFD4E713416D860EAA5D3AB70052D /* Cache+ForwardRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		55ED80AC201E95BA04B5DC8CF05F537B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
+		5728A34ABA8EFF53B7F9AF973D947880 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F546642C51F69052520612EAA9986664 /* DistinctUntilChanged.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		57A9D441866697C17FBAF6137D9F03FC /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F5167D86BA16961527E0E405A7149A36 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5865C7C727539B4FE606B6525CAEC927 /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73030AA83660A13E569AD0113EEB8D17 /* SubjectType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		58927D6F2EB4834B8E0F96FC15616800 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F239EF1F6D92241D56ABA8E4C73B440 /* Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		58C329E03AF257EAD5023AEC3F475AAC /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C656FB4C600D0B66A0CA26EA3CA1C6B6 /* VirtualTimeConverterType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		59A0B9FF62BD7D3BF1EC9F41327BA7BC /* Zip+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA1890ABEC35BB449F3F5683C6B2425 /* Zip+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		59F05941C92B87CA2719D455E2A7CF85 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8771C43A89854E33143BC1E490E982F /* Reduce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5A1B09C912B9630C872E2D30900ED305 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5ECA959FB88D251D51EB6430C7D29D /* TestScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5BD45FB9FAF04108A7FDF91BCF51FF46 /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11271157EE354CE9358AE9774380C0BC /* CombineLatest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5A4DB51C73E6A8EFDA81226D90B47E39 /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624AE40A0FCA86E1F3E1D79669BAF589 /* Dematerialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5A7D7153F2773BFCA1607F72E92B439A /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF8CF506C383DA0B139B097FCBADB1 /* Errors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5C663E6DB2E98D355C1BB362174AF99C /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E699A9C8240E18A9ABDF1DCEE7DD1985 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5CDB25EC8ABFC26513B4DFE9072CC7F0 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED041943DDAED283CAEC5877017A31D3 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5CF8106293869D3A64AAF22EE090B035 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E886E1FED4D952D5788F7C4696FA1F /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5E33EEB7ABFA2760656B87D8B6E72819 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DEF6971B000CB7E6C2A7079CD93E15 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5E48E67B2ABD87C14F5D3E57906B551E /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855E1F240198863501B0AD4F112A227 /* LockOwnerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5FE08B18FBF244AA9BB56F0CB350CFCC /* ForwardRequestOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 774EDA1B4043F601C2D055BDE59EFACA /* ForwardRequestOperatorTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5F0B8E417E2CA48E2F3AA1091272D9FA /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F88EB886E9B11A3ACE686A7DE97749 /* SynchronizedOnType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5F7283D929DC6885D32F3BC2001A1D1F /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F93BC7E647D0D2021806296CF59E89 /* RefCountDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5FE08B18FBF244AA9BB56F0CB350CFCC /* ForwardRequestOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		602229A466EA9CC6CF6EBB292FA92817 /* Any+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A6EF2A5694A31A5CDF6AF7E7B00AC8 /* Any+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6045F6B84465435FDA51BE8ED3D5595F /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F93BC7E647D0D2021806296CF59E89 /* RefCountDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		60C4BC7DDC49CF4950D21DB6A5283FC5 /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0D12CD7CA4FA31C47EA57756F53C78 /* DisposeBag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		613A85087648D76248BDDC254B4EC8D6 /* RxSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 586FC161DF179CF64CFFD5DBA3E8AA7F /* RxSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		618EEA8C9CBC83DFF17DFE6C683B991B /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE2787BAD6CAB49C44AC814A83A2ED6 /* SynchronizedDisposeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		61B78DD247A6ACAF4F5ACD509789F13C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50638A0FFF40CE3653E500FAB7819CF /* ToArray.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		61BA2BD935A823290AB8F7A856AAD5F1 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75861FD8178EE58B01ECD63DD21C67D /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		620AFB4970ED7996C38C781EE5104280 /* ShareReplayScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403CE64DFF46B860F390BF0D03A422D2 /* ShareReplayScope.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		61BC18D86FF21561A497ADC4D1865BCE /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0EB6A4389D465A59BCD1881AC9266A /* Fetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		627140526B26984EA9165F978D8C47E5 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F73266A196B3FE3BB0537221C3009 /* Do.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		62BD2DC0DE27B3CC5547033587D7F4E2 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429A78EFD4693FA32211655BDAE214CA /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6329C05469EDF9F7AF31A51F04DF1680 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F07E2AD84356249665F58A1256D281 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		637B13D9A814E7093EA737CA00CC7E55 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561ECF42DDB43FE546FAB01764F01B68 /* Producer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		648FB53B11B9D8147E4E73DCEF05AC97 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAC9F628163F0D65E621153714528FB /* InvocableScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		67ED2FD4423F3661616B3AFFD8EDBFD7 /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AE06D808F2F25DAA9F9ACDF64372B7 /* Materialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6456D893FD920D8901734FF59B7DA3E4 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED041943DDAED283CAEC5877017A31D3 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		691E8423DB01820E6983935709949B17 /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9FA296A61F02C71E067B65E060AF9A /* ObservableConvertibleType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6938331AF11B34267092E3295B450621 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178C07C7BE7B5B19970CE0A778488E18 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6981F42A9D6AEA3C59CD6606C1F6A724 /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B2C0000D84EC325E9E80E284B37A9 /* SubscribeOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6A6F2F9155AE191FEB5CC2D2A70257B9 /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624AE40A0FCA86E1F3E1D79669BAF589 /* Dematerialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6ABE9D236633C2CB157257F510C519E2 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0F4EE119E65A2790A5BEE531ED8E21 /* SchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6C3C2F7CE2F2D9E88AE09D5FCFA5A0B9 /* CacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06D3297663817AF304B6B70CABC112D0 /* CacheFake.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6EF5B9089F9C4E2D280B7FFFE03CEEA4 /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D1B3DDDC079647155BC0893F747601 /* ObserverType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6B79B943AC0114647C37C5C8F190C5AC /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFACB25ABE7EF55F68113515C4ED284 /* NopDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6C3C2F7CE2F2D9E88AE09D5FCFA5A0B9 /* CacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6DB47D362BCBFFE24A4AB8CD0577020C /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DF324C6A2B21E73811CBF46C7D33FA /* ObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6F2AECB6C7DFFE5CBE8183B0AE0FFB28 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BA43064F9A852B1B6860BCE449DFB169 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6F80471CB473DFADBCA8E9CEBA903A74 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9AF554228C539C0AD66F41BFA9CC1C /* Debug.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6FACBE27BD32B91E914476ECBEF3BC9C /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EA39E9E71A1FC29AA92E535D177682F /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		70B1B49D4F6AC4278B949E43B1A71C99 /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4838D06F6A58651D1B6B19228C82B07 /* TakeUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		715DE0702F64C0CE5D086F93BF303CED /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E1FCBDFE3DD9AF98DAA6B0274E8048 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		71B0F56FCA8DDD413B15FA01D9EFC251 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE53107134BAB0E0AC7FBF2AA1BC6886 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		71EB87EDD44013A62FCEBADB3347177D /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4208096FBE5A3697F4691455C57A52A9 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7233C02A9E2357048270B76C12F53CB2 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = D618449AFC6917EC84F2472DDF576D19 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		75551268340656C9AF7D8A8C49B35B67 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDAA2E09549A7E0FCBF9EBDD3D88519 /* ObserverBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		77FA2E279F8B9F30B7A5E79E4CFC5CA9 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A680D9DEB2C7328F188018204948F159 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7808094D34E63594E95CCEE856B9D50C /* ObservableType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA4E81E2A603ABE6B8DE1F922F5240 /* ObservableType+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		78978857E05FC2EEDBE5A79C098B8D40 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9677E9E790094792357AB00A80B5F99 /* Deferred.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		78E82035544790B21485DA869D2DF65C /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCDCCD2CB84A44273B4917DA700515E /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7908DE2BA5E510C1AB9322C1906CD05A /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD223D6831D0AC58EDFA33069A37F497 /* Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		737BF0731055BA94697516BFF81788D3 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561ECF42DDB43FE546FAB01764F01B68 /* Producer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		73A328FCE4AE1F06C999EB46025609F9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
+		73B6CB58A15C920155AA084FC2E222D1 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93367B5FFE412E86E6141363502F1B4 /* ConcurrentDictionary.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		74FD8FBE56488B3CBD5ECC531B847185 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDEDF71C13611D83ACF75918250AB50 /* Optional.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7506657507E58162596B63B5B33DACFC /* Droste-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DBA052779C5A889D0080E10D183D0E0 /* Droste-dummy.m */; };
+		78D4C07385E6964BF397061623A952CB /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C1CFBF23986F7F678D8874DF9471E6 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7A31FE8E8DA0619905B90B5C2AF5E792 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03A8B108B52F54A50E12C0F9ABB0C2F /* AddRef.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7B14DC948066CE6326C7E6A50ADBFAAA /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFC3B84174FAEC2D251A30EF3A7B52 /* SerialDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7B5067845726AE1DAF8E288BB2F2E102 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42CFB6F18F1DB156575243FE21B434B /* Multicast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7C0CE098C1446EE13F0CB591462AD283 /* DispatchQueueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A823B4CBE909FE21497D7A966D313 /* DispatchQueueConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7C2EF58B912E7259CC6D697B1B6F43D3 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0E2A8918AFEAB4B5E7E462139244A /* BooleanDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7D3235B869EC4E03C93667C9C163DEB1 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = B702C9652B23C8F94B293211DD96F3C7 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7D45240FD1FA308940F31DA57475D69E /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F73266A196B3FE3BB0537221C3009 /* Do.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7D71695D29F3E73697770D4EEAFCDFE8 /* ColdObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E5D67BF2841C2B6B8A7805B2BFB84 /* ColdObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7DC290E3B2877F32EC1B0AC16D16A4C7 /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 834ED52643B582A82D56536389F11FA6 /* World+DSL.h */; settings = {ATTRIBUTES = (Project, ); }; };
 		7E394284D01F55E407892097E309C943 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA059ADFF8022A8F87B7D63FB4614C8 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7E8B959FC0E11ADE51DE16EE46D40F16 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		7F7B286BF3C99EF4CB2711E8971CD24F /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801686A5B36A736D3641815EE1D4204 /* RxTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7FEEB9A55BB971E787C4F5253979EE61 /* Event+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790D1254BDA12208B89C11C83294C733 /* Event+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		829E539A90ABE5D080FD17ECFF4AE662 /* Cache+Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86808D9D54F9F1BCB707742064000F60 /* Cache+Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		830AA32E1370EC17E4BA11982F72B59E /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4208096FBE5A3697F4691455C57A52A9 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8184767E4E316D41FED0C84EB249021B /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D1B3DDDC079647155BC0893F747601 /* ObserverType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		81A48621A5DF28A72AF3A47EBE1AA221 /* AsyncSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8BF1B97667C167D9815FDD505BF522 /* AsyncSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		82311FFB6BC6EC9EEDFC0143EDE5BE1E /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855E1F240198863501B0AD4F112A227 /* LockOwnerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		83262CD39AE9A9BD559A810326CFC2B0 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F89F28CB63883E9DDDECBE8DA2928F /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		840A5966B0450CDC793A1BD2289BFBD2 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
+		84175B77120ADF5C9E3235F9BE0ABB9B /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFBAE0B2D0F4EDF8D893E80BFB1AE0 /* Using.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		85255B609E18C5FEC187E4F957DED344 /* TestSchedulerVirtualTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713A3DCE03735AC480D0E3DE0BC5EE1 /* TestSchedulerVirtualTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		85D264B5009002B7A79971C8413C870E /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C22A1615527B150C21741AF1D991D24 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		85ECBAC0D005D728D10EA42DCE71A7AE /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8590B74B6F82B567F528AF587959257 /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		886CAE18B7BE1FFC66877F770A137B2F /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8808EAB77FFB53FD5AE82864839F82 /* Buffer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		88783D2F9CD69110A4ABEC2031CB56C5 /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD067F7995E2B5EBCF8D7991F6C0001D /* Lock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8A4CC7A59C26F073C8E4FF501CEEA40B /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825C5C72FF462971F73D71DB1F4B853 /* Completable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8B85776BFF24580344B3C564682DC393 /* Cache+ReuseInFlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FE71F3465244B868B47B67787C3FE71 /* Cache+ReuseInFlight.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		8D6567C1F0DDBFF06DDE09D7550C46BE /* NetworkFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0331E71197D06F4AB4BF9FD768A1CD94 /* NetworkFetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		868F38DA2EB129D7E31A10424210243D /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5BEDED3CD0D8DDE85A2D11207DD18A /* RecursiveScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		87EFC9EDB8A4ED842D65F3181E585F81 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512FFE04700ECE71D158BF5B6F3A4DC /* TailRecursiveSink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		88458AA9CC1F18DB80A3A465561626E2 /* First.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BA10C614BE6C945F2AF6EFD8CD6FDF /* First.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		88FD3A43286D9B35A1F884B0E3175F34 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC23D858B2A515A23808022D5F2DD7D7 /* Just.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8A9F8AE0722E8E48209E567BF842B8D5 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390947F0F397720A36AA2256A8B80572 /* SubscriptionDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8D54AD51F563D9CA5D26129F7207976F /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B2C0000D84EC325E9E80E284B37A9 /* SubscribeOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8F30978017E120C71371DFF352F93202 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADDAFE8A1473712231745EE23863851 /* Delay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		920E53F0080CFED03D09DA32387F0F3C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AECE5F1CFACBB7D053E7C0D000BD3A2 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		920FDF9CDAFF2C29FDF5A20A2989DE7A /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11271157EE354CE9358AE9774380C0BC /* CombineLatest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		923A2A207D32196A384A162E6A39C7C0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1F9E5187F3C5AA1B098A820C8121AF /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		92DB1648024B40ABA39F9D6B6E121ECA /* Cache+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED138D8B32B115B3D81476C96343C303 /* Cache+Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		92EFBA0D7A20A381C3F4CDB81F098883 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B102093BA04370529D8C3EFE29F80 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		938F21910297686E2BB6385014868190 /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6F135951F0F23BEDF8068C9C66C27D /* ImmediateSchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		93D5AE24FFC003B522B6CBCC8BA908F6 /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C1CFBF23986F7F678D8874DF9471E6 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		94425C205FF57485B9D917947F7629B4 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7181441ED03EE29184C112B38209E46 /* Single.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		95240B8549B77F843BC647FE6F62CF85 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAE7C2A80A89C089E3A118C05B6E405 /* TakeWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9560906F63262392EFA38ED2CB3B8199 /* Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95332C62694E7BDC87A33226B19B43C5 /* Reactive.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		965E8B431BD4339D96A545827E348A02 /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1884DFC444445AE3DAE8479FA02472 /* DisposeBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		97DE254F328F62E9C18FD4D288591858 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452698D4DE0E21EA0996260EABB3D6AE /* CombineLatest+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		98B40E0377F8DAFFF705741806CC0415 /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AFCEBB293C8636E44263FE7E111A571 /* Fetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		99BB7DD86B9CAE3C91E033705B158FE7 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = B319C2062C21BF38BC241BE0C439F296 /* DefaultIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		99DBDB52508B157BF3F68F0FD55FD64C /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9AF554228C539C0AD66F41BFA9CC1C /* Debug.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		93B9AD814CD5D31E681DDDF38BFF66F6 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C452554BDE351A5CEB8E24DCFB934D /* HistoricalScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		955F35606B9FB8A7D94FDB5DC4DC588B /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3389D1AE2E13C76B4B14E029DCC420A /* SerialDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		969FE1B9D6B5F6F983838C9A7AD2225D /* Normalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234C79C3E2DF0647B7127BD9B736D60D /* Normalize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		98376684833F9A5718A9371C8D57158A /* Cache+Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87C44A47BD0F817D12FDE011002A153 /* Cache+Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		986DB9A3D4F74012981EBA5A9DF83863 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E47B5D388A4DD83CAB93471D121A92 /* CurrentThreadScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		98904DAF6E34263431D58E2CC3692BF0 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452698D4DE0E21EA0996260EABB3D6AE /* CombineLatest+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9A8FEF430D75035EA575F460AEC15D11 /* XCTest+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9A9C038CD72CF56CAC434ED102ECD494 /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5BEDED3CD0D8DDE85A2D11207DD18A /* RecursiveScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9AA4A43B2ECA66A6F5D500A76E942A84 /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DF324C6A2B21E73811CBF46C7D33FA /* ObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9B0FF4D8EB4EB068FF25EDF566BE5A1D /* Cache+ForwardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F05DAF38986867AA0D0C87E74A24341 /* Cache+ForwardRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9AE9B70764F86CD90EB32C1FF1D74BCC /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C656FB4C600D0B66A0CA26EA3CA1C6B6 /* VirtualTimeConverterType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9B43BA0E11406E19169A84DE6F1531C4 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9B82931CAF7DC34D81B207DF2A30E160 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A3D868BDEAE5EE7CBF2F39D26B8C2B /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9B956F87081C78FE2142CB966A82C286 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AFD76D04B1BF859FA77E7363C393977 /* Nimble.framework */; };
-		9BDF141D2C1AF32142212C4393F47BB3 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC31B2AEC5746A85819DD242B506042 /* SingleAsync.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9C3550115666116FA637AFB3F8D5E830 /* Droste-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 6863D80AA28BCED142271D15A24F88AE /* Droste-dummy.m */; };
+		9C88B661FC1DF8271417A1C054F46C21 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780A534B38DE71C0A2986E58F56EF23 /* AnonymousDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9CEC63C8A312477703953FA38D4DCF46 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B0C116AA997C58F9C6A65868A1329 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9DB7DFC45C14E75960D53BBAA0E79975 /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E91B5759B010D20E06F6FDC133675F5 /* ReplaySubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9DFC45C404CABB05A60B2BA7B7D89814 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDF9BFF6F914D4F8E12C8E5F85922F9 /* Timer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9E948C88896507C1BCA4ED24E3B440C3 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C4436206C8A0E350BABC0165A4DFEE /* Observable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9EEDBA8ECFB03AB675FA2683EB955D94 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42CFB6F18F1DB156575243FE21B434B /* Multicast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A0484841A82039EE20C7D2692E9FF443 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDEDF71C13611D83ACF75918250AB50 /* Optional.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9D196D25057E03F88EF5D9E525DD96C1 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8DA031C932F6A1387C77E541154CC /* RxMutableBox.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9D1FC1AF8CB4C716C9807CD6FD1F67D8 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAC9F628163F0D65E621153714528FB /* InvocableScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9F2376A521E351D92CEF44A0D5F01404 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4AD59559CE5395612189B0ABF91761 /* ObserveOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9F92C1A2A795C5F648FDEDA434E95031 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F54A3B30611A47020ECCDA28872E892 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A18D1604A0B3A836C1EE6530A3440EFB /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DC5812F31B21591951EFBAF40445FFB4 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A18F142FFCFD7DCF776DFF3CE0C644AD /* PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599A56FB0BD0A419A50451DADC8E2D60 /* PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A19D89D3683E4368230D52014DC2D77A /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CB075012E5CF90FC620CE801F83F7E12 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		A251B95396E8611BA18D8AE59C0A3981 /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D02803FF50E3F48FF54BE828EDC2A50 /* PublishSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A336C23F7C23DC23DF6FDD5F0CECFCC3 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6D2B2E9F09759467884361D3E27E69 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A4BC6C72C51E19148125E207BE9A8369 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFC985C0C75E35B4A6AE383A847DCC5 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A4DF1E0D85844B0822237036EBCAD337 /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9223DEE14F4E1C27E97461952AADD3F /* GroupedObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A4E2B29C80233AC31021A2309A0A9155 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7859A6745A8C7479D62F97438EE65404 /* ConcurrentDictionary.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A4EC249AB8725E04B8C310D785BFE993 /* TestableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97A167AE3E61565ABFF1430236CD2CE /* TestableObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A52D59AF157A7CAC42C346D5E3F9C7A6 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC2626B8358940692B134A160E14C32 /* Cancelable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A52D7659626B9CEAD5C14DD4B4149A2E /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58E0F0B1A3B6F28663FC08EB3ACDE78 /* Repeat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A620F798081291E0BF981FACCA5C701A /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7DD93F264BC535D061EC8536AE9D8B /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A635C44A2419A9684A22993B4052CAD6 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55533DD388D650E3B3D03F21B5992570 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A79E72FE105B16E7C6A6FBC79D7D0E7D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E496523B5977D63BD4BE1FC835F03A1D /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A83CF92242521C88CA0D0551D4C33A06 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA7D068830C8E38B73913ABA551D6AA /* TakeLast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A878734D3B6D3901860088A3E5C3254A /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFC3B84174FAEC2D251A30EF3A7B52 /* SerialDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A7CC61771761DD01B0ACC51BEC261700 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7D715D5363605B3D84F701394CA127 /* Event.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A869B2D61FA859B7EAE37AD82830DF02 /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B189A16C05A14C69624B1D23DEAB3C /* AsyncLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A917918EFE191842B5EE36EF3394AD74 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36512327D1A7F96D0F72E260C392CB4 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AA34E372CFB45D35141B662D43E2B1CA /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814356EE1E9605CC4A9AC25448622168 /* OperationQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AA5A068949E7731A8A2523D2A432EB45 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8328E7C0D6403714ECE7338CC9440073 /* CompositeDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AD0FB6691F54959FCF08A42C63EFCC3A /* DiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 41E67485AB4DE9E206FB2B3D9AE20F9D /* DiskCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AD51675635B8745A1A0C021F1328E63D /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03A8B108B52F54A50E12C0F9ABB0C2F /* AddRef.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A9E5824BC7FD57AEF46D9F26E0EA9444 /* Caches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC750EC952E121097BF47124F783F5E /* Caches.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		ADB92CFC629B21F098BAEC90D415555E /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E48E4CFF3E795C7F7FC6C05461A260 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ADBE46FFD944AE1D82BA9B45427182EF /* SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF2545CB5297ADED2671AA2BB54FB461 /* SkipWhileTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AFDD57288C4B2706C61738929D23D8A1 /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3389D1AE2E13C76B4B14E029DCC420A /* SerialDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		AFE8E7890E0E5EF2228F52BBE6D441C1 /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E8F0725F629126DB6F582017176D9C /* SynchronizedUnsubscribeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		ADBE46FFD944AE1D82BA9B45427182EF /* SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B00EFAD11F1688A53D238E159B927B0B /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC071859004A73F33D532D5F42FF61D /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B0C72020BCE863374F0BC3DB4309A924 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = BD4A59E727AA546B89DF4132569CD49F /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B1EBF61F0F3922F1A7BE4223E9D53703 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1D4526BCB1D674C22D81B95CBB4612 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B367074DB2213FAA1691102597FF7EC6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 729BB400C567E6BEB87A66592000A7F8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B20298FB9142E271D9840CB113897ECE /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = D220738394C885CAE465F0CC85974514 /* Window.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B22125F12086DDF6F7C60A61DFD7AB54 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF8963A749934021EE631E46FA8D10 /* Debounce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B367074DB2213FAA1691102597FF7EC6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B453A74BA45777678EA48C8167C550C5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
 		B4BAF015C8BFE16A986A3EC50C6C015E /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE9A9B5D9C6D7155ED2F3AF4A912C26 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B53CB156734BA4AF716A555B86835701 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763782B58373E3F28DE2DCD725868E02 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B554A2742210AD6F85A6A0736D76093B /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555905450B901A902E8F94CD656E4D97 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B5B2E421BCB6D195CE3F2C03DC8E4FB9 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F89C69F00F905174B0FFBEBF16B23AC /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B69A88434BAD97CAB3E2054A950B8D72 /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6F135951F0F23BEDF8068C9C66C27D /* ImmediateSchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B6B8C4D3AC2DECB5235003BAFE605603 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F466C67722461ED16EEB149A87B6B44 /* AsyncMatcherWrapper.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B80B26512BDC6877614B7261B16C27A9 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB84063868E7FF0FEEACB89F09651C18 /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B9E4929B50A4BAD5701FB9542002525E /* RamCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C9788D832534414037D108368A8A708 /* RamCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B9F5EC8B7FEC3F9063FBCA48BCAB96DD /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90117FABAAFBA5499FEFE1ADD97272AC /* Zip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BA1AE78FEA0A72A6466E4E1C9C0E8479 /* AsMaybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F96F3E7E0E183E02B71545016D7559 /* AsMaybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B813723B1CEBE911CB1ECA4A0B512CC3 /* PrimitiveSequence+Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36C37D0620E19DE982B14EE97CB492D /* PrimitiveSequence+Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B9612A6A6744C5195724CC6ED08B72BC /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E91B5759B010D20E06F6FDC133675F5 /* ReplaySubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B9E4929B50A4BAD5701FB9542002525E /* RamCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BA1FAC97337A997DDBDE9AEF2AEA7A75 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E16CB41EEE80933DC59102A1CF876EA /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BA26560D1ABFDB1CB344A7EF6A7595D4 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C823EEE007452668D8D018D5A5EC0 /* Throttle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BA33B40D5D5F31B79D965ABFB8D3C923 /* Cache+ReuseInFlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C57A36289AA8F980AA9BDB67D172505 /* Cache+ReuseInFlight.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BA39B670C01B024FA6756E32A48280BE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
-		BAF99DF586BDB43C112A0C19FBE2308E /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A90C41F1F0F546F4FE02F94B36DEDBC /* Concat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BB2CFA70A57B42F5EA411A9F26A1DEA8 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB5546987339D3006C11834A93DA985 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BB55CE309B316A92FC2DC8589432BF0D /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512FFE04700ECE71D158BF5B6F3A4DC /* TailRecursiveSink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BB34681BD5746576B16270AD676815F2 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A680D9DEB2C7328F188018204948F159 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BB77F3591B3C495A781E5EB0EAAAC11E /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616271A38C3EEDFCB5D35828D794B2F /* Disposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BBBECC463322F65D4D03D6295D1BC5CE /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C666618A086B6BC13A87EEEC55D5051 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BC6E55CA5C9295B2756FAB91E56033F4 /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FF73BA6D2BE9A0DD6E2B7FB04382EF /* ScheduledItemType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BC990A5DC96C7060B48BC1E95B04443F /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BD64FCED7B504354A3E304CB75C022 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BE2A47CB3A4EAABCEFBDFFE3AFCDDBAA /* Pods-Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C9BDE82371C83FA9AE91B05F77ACAA36 /* Pods-Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		BEB766652E3259FB68FC74B7E39FFE0A /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF8CF506C383DA0B139B097FCBADB1 /* Errors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BFE2AE907B3DFEA669E43ED77E6115B4 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390947F0F397720A36AA2256A8B80572 /* SubscriptionDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C0331819D5BA3B306B51B338C0CF06CF /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D122B4BB2E236A54975BD2A0227F3A /* Range.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C09336ACB4D11C3629F19E1B4681281B /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE885E75504F9F1BF14039E44FB01500 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C12F0FB7402DE4A2770978C5BB4C6850 /* CompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7C51489466E65078F9C8DB22E2C77722 /* CompositionTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C12F0FB7402DE4A2770978C5BB4C6850 /* CompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C1E82F9FF2CD436979970279B888205A /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF943B822AE7953A9003EE518D903DEA /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C2887A332D9BD897477B72B0238D65D2 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F97F9E0F5FA166C24534977251F38 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C357FB2E6BC6670AA2AF6DE89F5888F4 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
-		C442644A32C247F67063C6609348A980 /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B3ACC3A810F1D86386DC66DD864706 /* ConcurrentMainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C453A503755C9EC292831E24357B4F0F /* Bag+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB2550B5110CA4FB9C6FD26836A6EBC /* Bag+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C527FF40212046670FD1641E63B0CD29 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DF399EDFBE684FB01A9134183BDC79 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C5AD12068E297DC2244569981DBD75C1 /* ObservableType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA4E81E2A603ABE6B8DE1F922F5240 /* ObservableType+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C6EE3EBFB01CBC1D9906A7A7E4FBEED1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		C86420D4E85D7723D8D194C181B851C5 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65B7F488687567D2AD4AEB111AAB8BA /* Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C78421AC4626B27875380626A5EC5F0B /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E8F0725F629126DB6F582017176D9C /* SynchronizedUnsubscribeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C7F89C4A0EBBE2EE0A2B5382EF62B2F3 /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3DD92AFC2E510C7B449FED87EDCE01 /* BehaviorSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C8A09A059FF9EAF51DEC9ADE2BCA6250 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06464B3E1258E03B1C46A2DD64028A76 /* Subscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C8BF9C21FE17FDB7D765400C55C9F022 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BCCE1CBFDAB8CE24C44B3C3FECFA4E /* ElementAt.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CA4ECD10AE858BEF37CAFBE01E4D36C9 /* DiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2EDD7BD06778C4A66DD3B695604617 /* DiskCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CA882FE5A3E6F480BD18DD67D966F3C1 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FAD19357A80957099904472A89B7FA0D /* Nimble-dummy.m */; };
+		CAC5DE6DD742D9FD24FE7DFA1A748130 /* Cache+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7887A82F93E99219E90E8C6BBA5125 /* Cache+Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CAED3B4F1864F2283C0B956968F84089 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D050E7B4E77C5F8F398043AE2B42DD /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CBF543BC6E297BEEA334826F14815A0E /* Droste-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = FC763FCFA189C1D9D227FDDCCA75A22E /* Droste-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		CB541B3618202988A7918CD71B016111 /* CombineLatest+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F77F4B181B08425951C1175E1C5714 /* CombineLatest+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CC1263FF41D9835F846B465CCBA7C49F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		CC12FFD5BAD0834C3974E340673BD861 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E18A7FF7CBDA9450CB94DEC9DC7F70 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CC3606C5BF3322C22DE176521CF61AD0 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A6A90586B5D6FF6007D3A8CAE078A /* Generate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CC4A3C05831E7277B810E77ED26DD7B6 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0E2A8918AFEAB4B5E7E462139244A /* BooleanDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CC8E9462D1FAEECEA04E0716A18B1A50 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B139738E8AB1BCB198F68731ED0053 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CE2484C9FC0C3BBA40DEA9E2CA5ED960 /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEF59E38EE96A73E582FC4F0B2CCDE8 /* Recorded.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CE734BE34EE2348D771A827FCB24B875 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC43508F7BCF0D0844BC4CB3969BE63 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CEBBCA1BDE73EF3BB0D808489A089D67 /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FD76819C1FCE81806064C89E577597 /* Catch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CF14CEE4CE4FB9E86123214E940DE63A /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EAE65D1A37CBBBF2C4FA465BAFD079 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CF9DDB2E269C971AE852D778A8CCB300 /* Cache+Salient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C6C3312968F391BB4825634B645E7DC /* Cache+Salient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CFA899A6977D2252AE6B33761B0EE0B7 /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF67B416E1A9557AC0D4822F59DD545 /* World.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		D015517ABDB5B56ACE6BC9B944FE2601 /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D02803FF50E3F48FF54BE828EDC2A50 /* PublishSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D030394158D6960DBD2C200F8CD06D27 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4250907D10CED5894873CB05B98773 /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D0349514048A756AD550ED37322ED591 /* Droste.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7212959077D3C9F5654377DDE47A6E15 /* Droste.framework */; };
 		D0676BDA3BCB33B0C778AC93180963A5 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 664E444158D22087931A52AE7C54FFC7 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D0CEB850FE25772437B1A1CBE9A767AD /* Cache+SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 99D13491843B612FE7764BD718E937AB /* Cache+SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D0E6889059151B7696884B3CD0921C21 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456AA1151E2EB02F7FE37EBBFE64EBA0 /* HistoricalSchedulerTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D1E2FA965DB95066E3ECC9F2D90B2773 /* SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 198D8EE76D918CCDC8303E28606BF574 /* SwitchTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D293BABD4ACF596061B9C47C0E40CA26 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE726664E88FA4A800280396E6EBE7CA /* Disposables.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D2D9E870761EA21B32DB45DADED99D2C /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3517B45D9C3D29D33E054064596EC37D /* Sample.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D1E2FA965DB95066E3ECC9F2D90B2773 /* SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D2CD3EEFFB8E600628F1884B7DCBC466 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C64788EFA087B5960001B6155C636A8 /* WithLatestFrom.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D2FE3CC7D9FCA5AA95833EF39E8E00A0 /* Maybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FDB452C5DFA7C19F6658D53AF9F8A3 /* Maybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D3CFC809A9CBE1EF88F4F3337C4B775D /* RxTest-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A73C789D855DEF04139E173F02CE64 /* RxTest-dummy.m */; };
 		D48BF578ECC0043772B4E83CF8D27DB7 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4353C7E8B48EF2A0828594A6E1AEB458 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D4CADA0C35E0B6CC281C99915CDAEBA3 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		D58A2C27F18C5386AC39A340968E0C0B /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE859F7B131C3DC21704FCF269B10A53 /* DiskCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D5CC02225146A5DEF9E2B6DB3CA8941E /* ReuseInFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8EA8699D8B688DA6CC281E609C0014A7 /* ReuseInFlightTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D758FBEF9A6870F8238255833527F80C /* CombineLatest+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F77F4B181B08425951C1175E1C5714 /* CombineLatest+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D94F2290ED80DA41317503A900341AE3 /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E96538CB79CC8AF348E3364422431F4 /* ScheduledDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D988EF541FF163B7211000F207E6BAF5 /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B9AC2AE3E5160F770D7E24A360B21 /* AnonymousObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D4B0746F12B5C2221EB678275BC076B4 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAE7C2A80A89C089E3A118C05B6E405 /* TakeWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D58A2C27F18C5386AC39A340968E0C0B /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D5CC02225146A5DEF9E2B6DB3CA8941E /* ReuseInFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D735E672683E25B2458A468C0F7F5B39 /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B3ACC3A810F1D86386DC66DD864706 /* ConcurrentMainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D87CB2C19CD44249826B5517B11B4D34 /* Cache+SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02725AA6B05AACA955021B485CF40E0D /* Cache+SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D89F5FC51EFB96CE73F7740BAC34253F /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA885A063120E9224890A1BDF6C0E8B9 /* DelaySubscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DA494E8BBDEF2913F85E33183BCE1BF1 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7181441ED03EE29184C112B38209E46 /* Single.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DA4F9EB339859168966BD00BC30981E0 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C036E198D7FA1F251CE2C2D623B8EC20 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DA581B2FBE4E23E6224202323B950CB4 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7AC420CAE15DEB538D454C10292A84 /* Completable+AndThen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DA8EB1D95471ABDE6CA6C3486EA99463 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02932E0F16695277F04D1B0CA7FA2C2 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DAE19DAC20BD3B93A30F5F4BDF61D622 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E96B4FCF763CCF5848F3A04BDEE3C /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DAE250AA7A17528D8EDE26BFC3D14D71 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C162ADAA8658A02659DCAC1E8364D596 /* ConcurrentDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DB74F2597C6240EFF3AE7DE3F9AD1CCB /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5F9FA62D15DA8072B6714CEFFDC103 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DBA334B9C35E5354E5E81B790C836BC6 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = BD4550F0446F62D284F47CECFFB7CF7C /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		DCCCB6B0197B7AE37E472D28BC81D08B /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE18E0BFD2918C0E3F1B5AB26CA5D95F /* Take.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DCD0BA81DAF12E219330DCA13D8F30AB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DE7706A07C9E786D7CFB831E936D8FEA /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1884DFC444445AE3DAE8479FA02472 /* DisposeBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DEE0EB0FDD41001482465830F89E6A9D /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD1E8FEC73AF4E7DCE459A7D16BAF2 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E017FEEDBC4EFA974EDBFA4831CAC7A5 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28754340AEF03EB84EA98ADFDCF1EE5F /* Empty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E0A7D6836C9A3242B4ED3B7D7EFE7D75 /* RamCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9609E7445AACEDC561F4A22C96B9ACB /* RamCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E0BC3784027574E48764B59D168EA9B9 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA31BF7406BCC195F45681092F5E2A /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E0DCF434E4F151A17F4E3DA6BF6F34C3 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E74A6E007520ECCE695064780621BC4 /* String+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E1FA8607DAAF43BF240C8FBA9C560A8F /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FD76819C1FCE81806064C89E577597 /* Catch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E244EE6DD1CD7B6B24871510C1A33735 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC17FB90E566827515A71578B2BBA3 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E259564A33E97FCDE260E5261F7EBB75 /* DispatchQueueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A823B4CBE909FE21497D7A966D313 /* DispatchQueueConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E2B9515C01F752D52C0C73E004E6A0F0 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 74E4F5A94A6C5AB2493BE2DA0F47F7A2 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E4408EC7783D0BA7B2D2EE55D38482C7 /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5F9FA62D15DA8072B6714CEFFDC103 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E2C03D3EE79FAEDCD3AFAABE0C61F1AA /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A853DBF6D21EC875FD8AD8B1F1EE71 /* Sequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E4BCC2EC3DAC29A3CE9CD05DC274F633 /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A90C41F1F0F546F4FE02F94B36DEDBC /* Concat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E55ACC4131DB9B535FE3D6E56B3633EE /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4838D06F6A58651D1B6B19228C82B07 /* TakeUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E720CC01C8CA5C0DDB57078682328DAC /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F099B690CEC2A42B92999FF085FBD9EC /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E72DE8266B35092258B18D7B22B64566 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14688EEE13E18098791B2E48FF192795 /* RetryWhen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E724A866E04A8903CEBD7AA05FB9DD2E /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8590B74B6F82B567F528AF587959257 /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E7F0FF8B1D94AB9A664B0DCED67B1189 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5405B04137B75CB6DFCD07879C98E13F /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E91D5333B1BFFC78AC1D942B9CCEA0C5 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F9554E85E94DB66EDF8F5964EDC0C /* Scan.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E965A95077F792A9FC7460640BBFEBE4 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4614C36300843A53B2E48EB7750C0F /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EA768A0C0F383FA71D7D2A486646F266 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = B319C2062C21BF38BC241BE0C439F296 /* DefaultIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EB0059B940120E9B5C542B5B90EFB042 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCDCCD2CB84A44273B4917DA700515E /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EB393AE3D576DA534054C79DE95735B8 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8F7F09C9A6A330BD5F368C8609657 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EB706C8A7A10FD491AB6B163CF1D2A97 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9535482AAB6042AA7B9F4708C95A8F1 /* BinaryDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EB8ECAEB27B4A2EC19B3BB18EA6AD193 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2318D795FE872771B8CB9D1BEAD0E1EB /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EC73F9394930FBFDDC833EDFFA6857A9 /* RamCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = C73EC0C10314B30C0A3B90FD210AEDC7 /* RamCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ED1390662B68932D6E56E4237A1DF755 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBB5EB74E0D9C84930C7438F7640E03 /* Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ED3482ED68B679C4285A26E51263280A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		ED99D8FB1BA3D24666EF6436DF54951E /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8DA031C932F6A1387C77E541154CC /* RxMutableBox.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		EC0A195F17EC6F5BE98231A71CB36943 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDAA2E09549A7E0FCBF9EBDD3D88519 /* ObserverBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		ECE3DD34C51F1D409187936CF471B227 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537A211511A8B2175890320C5F6414D8 /* Timeout.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EF78F2E60D13696826206C4079ED238E /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D42A9F7F0C4E92C7D8065D70B4DD6AFE /* Quick-dummy.m */; };
+		EFAE161FDCA95823BCA7AE8F2E75BF2A /* NetworkFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD21BA2BB3EB0AEFF28486AF4D2144D3 /* NetworkFetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F02213CBB1768C8EFB1FFAFCB606C163 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B1B3A690A4215A45B8E138937F690C /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F0AE3DA6E950970BCE1C5DEDF3551A01 /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = D9B4773C9426A35F0E66C65A258CF3C7 /* NSKeyedUnarchiver+Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F2B56C38AC34F501253BD69ACD625D93 /* Droste-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E263E33E01E12E632D7FE81BF1D949 /* Droste-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		F2D512FE8E6A962E0630F127AB8A0489 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E59896EDF05625CF489C9362A4C628 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F38978F25150F1455F75BED67388195A /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4CCF58DC99E09361656CDEB3F969AB /* Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F4A4FA47C7EFC8E3F2995BF42C3EE6CF /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADDAFE8A1473712231745EE23863851 /* Delay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F34236CC526B8A4265F76F154ABF411D /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9223DEE14F4E1C27E97461952AADD3F /* GroupedObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F38F0A4FBE7BFA39F834A31356D3C4DD /* Cache+Expire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2875E2E9FD1B98E7176DDC0B2FAE62E8 /* Cache+Expire.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F474BADFE74D089BED1A044C43441AE4 /* Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780C8A5F17502180FDB54824FD3F810D /* Create.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F58C2663738975CE7FFE8C757F6D6296 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1CE888EF874F9D96852F9371F34FEA /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F7398370A42FC5B84DC8C806DF9F880F /* NSKeyedUnarchiver+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = F0FBB7DD7B55AB2DC4E26F3B3246966F /* NSKeyedUnarchiver+Swift.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F7D9BB3DBD269AB01C9A828F8ACBC836 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F92AF7638D9F00B37B06CFAC928BCC /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F8632FF906031D3939B941F6F6D7B00C /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 446AA99E502C856B575FA5D1DCAC47B5 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F9153BFD39BA965E84128BD2D53349BF /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C47A86BF8ACB0C8A501B53C54125E6 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F920282F625DA5BB4CDA6E67CE519107 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 62464D8F67EAAB5510738B1565044ADE /* Cache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FAF3E5B81AA669C708533C8F01F7C14C /* Maybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FDB452C5DFA7C19F6658D53AF9F8A3 /* Maybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FAF36F05C93A5AA8F8CDCC7835E5A484 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC31B2AEC5746A85819DD242B506042 /* SingleAsync.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FBBA1E4B4DBE81B4DCFDDE8E36061068 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7AC420CAE15DEB538D454C10292A84 /* Completable+AndThen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FC04B2AE30A8B8DB7081F988578B6147 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 144AA2A04F9B8638D587586EC4E32F4A /* Quick.framework */; };
+		FD10B27E735E32FA6B8002F8F9C5DEEE /* ShareReplayScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403CE64DFF46B860F390BF0D03A422D2 /* ShareReplayScope.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FECE46344B0F8264B338456378E0F027 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738135910E0064CB147B94B21A757452 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FF9A344AF4EE62A205C4BD199AAEA5C1 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DCDEB24981E3CB732C4381FA626D10 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 /* End PBXBuildFile section */
@@ -344,21 +345,21 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C8C978746B6442E1BF1F2F4A81B2D6E5;
+			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
 			remoteInfo = RxSwift;
 		};
 		1699F41ADAEDAAB9AE67F6431482CD89 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C8C978746B6442E1BF1F2F4A81B2D6E5;
+			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
 			remoteInfo = RxSwift;
 		};
 		4690A10ADB93BFF49EF15AF09554C1FE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = DD99D696E5267913E4B38DE2607FBAF8;
+			remoteGlobalIDString = 6BB8A926AFD1D0838DDCF56EF0045469;
 			remoteInfo = Droste;
 		};
 		891D036854C8540C4A334219AFB90811 /* PBXContainerItemProxy */ = {
@@ -372,15 +373,8 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = DD99D696E5267913E4B38DE2607FBAF8;
+			remoteGlobalIDString = 6BB8A926AFD1D0838DDCF56EF0045469;
 			remoteInfo = Droste;
-		};
-		BD8433840EF50BF5D2E026E07BFAF5E7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = C8C978746B6442E1BF1F2F4A81B2D6E5;
-			remoteInfo = RxSwift;
 		};
 		C0FC7C7F3EB8010BB106CC5937F46C30 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -393,7 +387,14 @@
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
-			remoteGlobalIDString = C8C978746B6442E1BF1F2F4A81B2D6E5;
+			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
+			remoteInfo = RxSwift;
+		};
+		E7FAB65AEDCB1EDEF0569E45A618BDA4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
 			remoteInfo = RxSwift;
 		};
 		F8F892A517324F6DD774820E501BBA41 /* PBXContainerItemProxy */ = {
@@ -407,13 +408,13 @@
 
 /* Begin PBXFileReference section */
 		01E6907CF2644EB1CF8E23F708A3DA0B /* Pods-Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Example-resources.sh"; sourceTree = "<group>"; };
-		0331E71197D06F4AB4BF9FD768A1CD94 /* NetworkFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkFetcher.swift; sourceTree = "<group>"; };
+		02725AA6B05AACA955021B485CF40E0D /* Cache+SkipWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+SkipWhile.swift"; path = "Sources/Cache+SkipWhile.swift"; sourceTree = "<group>"; };
 		0424E1790219422B7EB6B251ED7429B0 /* SwitchIfEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwitchIfEmpty.swift; path = RxSwift/Observables/SwitchIfEmpty.swift; sourceTree = "<group>"; };
 		04477B7B6A9631203A96E716F9B8E4DF /* RxTest.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = RxTest.modulemap; sourceTree = "<group>"; };
 		0549EB263233A4E143B87A2CB6B7DDED /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
 		05B139738E8AB1BCB198F68731ED0053 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
 		06464B3E1258E03B1C46A2DD64028A76 /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subscription.swift; path = RxTest/Subscription.swift; sourceTree = "<group>"; };
-		06D3297663817AF304B6B70CABC112D0 /* CacheFake.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CacheFake.swift; sourceTree = "<group>"; };
+		070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCacheTests.swift; sourceTree = "<group>"; };
 		075EB582A63C32140E7D9741CF677CA4 /* Enumerated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Enumerated.swift; path = RxSwift/Observables/Enumerated.swift; sourceTree = "<group>"; };
 		07B1B3A690A4215A45B8E138937F690C /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		0801686A5B36A736D3641815EE1D4204 /* RxTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTests.swift; path = RxTest/RxTests.swift; sourceTree = "<group>"; };
@@ -424,11 +425,11 @@
 		09ED5D24C2B42766C425AE76FACDD05C /* QuickConfiguration.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickConfiguration.h; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.h; sourceTree = "<group>"; };
 		0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
 		0A4250907D10CED5894873CB05B98773 /* Platform.Linux.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Linux.swift; path = Platform/Platform.Linux.swift; sourceTree = "<group>"; };
+		0CCEEF36C09885B713A3D7560E100904 /* CompositeCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeCache.swift; path = Sources/CompositeCache.swift; sourceTree = "<group>"; };
 		0E96538CB79CC8AF348E3364422431F4 /* ScheduledDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledDisposable.swift; path = RxSwift/Disposables/ScheduledDisposable.swift; sourceTree = "<group>"; };
 		0EE2787BAD6CAB49C44AC814A83A2ED6 /* SynchronizedDisposeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedDisposeType.swift; path = RxSwift/Concurrency/SynchronizedDisposeType.swift; sourceTree = "<group>"; };
 		0F54A3B30611A47020ECCDA28872E892 /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Queue.swift; path = Platform/DataStructures/Queue.swift; sourceTree = "<group>"; };
 		0F5F9FA62D15DA8072B6714CEFFDC103 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = RxSwift/Observables/Filter.swift; sourceTree = "<group>"; };
-		0FE71F3465244B868B47B67787C3FE71 /* Cache+ReuseInFlight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ReuseInFlight.swift"; path = "Sources/Cache+ReuseInFlight.swift"; sourceTree = "<group>"; };
 		108EFBCF28406ECBB643D5EC949493CF /* ObservableType+PrimitiveSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ObservableType+PrimitiveSequence.swift"; path = "RxSwift/Traits/ObservableType+PrimitiveSequence.swift"; sourceTree = "<group>"; };
 		11271157EE354CE9358AE9774380C0BC /* CombineLatest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CombineLatest.swift; path = RxSwift/Observables/CombineLatest.swift; sourceTree = "<group>"; };
 		119072C64A19799964E1620D83F514FB /* Pods-Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Example.modulemap"; sourceTree = "<group>"; };
@@ -436,24 +437,24 @@
 		14688EEE13E18098791B2E48FF192795 /* RetryWhen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RetryWhen.swift; path = RxSwift/Observables/RetryWhen.swift; sourceTree = "<group>"; };
 		149054C495E8EC590CAB4C524133016F /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
 		15A3F3BF839B9897E261ED3E39FE2649 /* ScheduledItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledItem.swift; path = RxSwift/Schedulers/Internal/ScheduledItem.swift; sourceTree = "<group>"; };
+		15ADFD4E713416D860EAA5D3AB70052D /* Cache+ForwardRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ForwardRequest.swift"; path = "Sources/Cache+ForwardRequest.swift"; sourceTree = "<group>"; };
 		178C07C7BE7B5B19970CE0A778488E18 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
 		185AF272F0B6DA8C8F9441D231093075 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		198D8EE76D918CCDC8303E28606BF574 /* SwitchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwitchTests.swift; sourceTree = "<group>"; };
-		19931B0C3BEFF5E9ED997DD64BC3F996 /* CompositeCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeCache.swift; path = Sources/CompositeCache.swift; sourceTree = "<group>"; };
 		1A82A5891550F89601465A5DE5BB7434 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B4F446ADE478C1C1E01A6DF2EAD0BEE /* Amb.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Amb.swift; path = RxSwift/Observables/Amb.swift; sourceTree = "<group>"; };
 		1B5ECA959FB88D251D51EB6430C7D29D /* TestScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestScheduler.swift; path = RxTest/Schedulers/TestScheduler.swift; sourceTree = "<group>"; };
 		1B7AC420CAE15DEB538D454C10292A84 /* Completable+AndThen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Completable+AndThen.swift"; path = "RxSwift/Traits/Completable+AndThen.swift"; sourceTree = "<group>"; };
 		1C0F9554E85E94DB66EDF8F5964EDC0C /* Scan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Scan.swift; path = RxSwift/Observables/Scan.swift; sourceTree = "<group>"; };
-		1C95587B4613F96050C6DDFA23317AAE /* Droste.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Droste.modulemap; sourceTree = "<group>"; };
-		1C9788D832534414037D108368A8A708 /* RamCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCacheTests.swift; sourceTree = "<group>"; };
 		1CBB5EB74E0D9C84930C7438F7640E03 /* Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rx.swift; path = RxSwift/Rx.swift; sourceTree = "<group>"; };
 		1D0D12CD7CA4FA31C47EA57756F53C78 /* DisposeBag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBag.swift; path = RxSwift/Disposables/DisposeBag.swift; sourceTree = "<group>"; };
 		1D8670ADBA31F83F75BA94F9ABA974F3 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
 		1F760993273BAFD1F853A8923273368A /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
+		20E8BD9801D9F2445DF683A261C21ABA /* Cache+Compose.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Compose.swift"; path = "Sources/Cache+Compose.swift"; sourceTree = "<group>"; };
 		21A8F7F09C9A6A330BD5F368C8609657 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
 		2246F5A3EEE692B98D8A90CF2FCE768C /* Nimble-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-prefix.pch"; sourceTree = "<group>"; };
+		22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Droste.unit.xcconfig; sourceTree = "<group>"; };
 		2318D795FE872771B8CB9D1BEAD0E1EB /* BeEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeEmpty.swift; path = Sources/Nimble/Matchers/BeEmpty.swift; sourceTree = "<group>"; };
+		234C79C3E2DF0647B7127BD9B736D60D /* Normalize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Normalize.swift; path = Sources/Normalize.swift; sourceTree = "<group>"; };
 		236A1615673613BAA102B28BFF25630B /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		24D050E7B4E77C5F8F398043AE2B42DD /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Platform/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		26F92AF7638D9F00B37B06CFAC928BCC /* CwlCatchBadInstruction.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchBadInstruction.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlCatchBadInstruction.swift; sourceTree = "<group>"; };
@@ -461,6 +462,7 @@
 		27E886E1FED4D952D5788F7C4696FA1F /* AdapterProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AdapterProtocols.swift; path = Sources/Nimble/Adapters/AdapterProtocols.swift; sourceTree = "<group>"; };
 		28089142BAB02F317AD1CA3C743F4161 /* SourceLocation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SourceLocation.swift; path = Sources/Nimble/Utils/SourceLocation.swift; sourceTree = "<group>"; };
 		28754340AEF03EB84EA98ADFDCF1EE5F /* Empty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Empty.swift; path = RxSwift/Observables/Empty.swift; sourceTree = "<group>"; };
+		2875E2E9FD1B98E7176DDC0B2FAE62E8 /* Cache+Expire.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Expire.swift"; path = "Sources/Cache+Expire.swift"; sourceTree = "<group>"; };
 		2A0F4EE119E65A2790A5BEE531ED8E21 /* SchedulerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SchedulerType.swift; path = RxSwift/SchedulerType.swift; sourceTree = "<group>"; };
 		2A1F9E5187F3C5AA1B098A820C8121AF /* ThrowAssertion.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowAssertion.swift; path = Sources/Nimble/Matchers/ThrowAssertion.swift; sourceTree = "<group>"; };
 		2C7D61CF3A98284AF8463F2016518264 /* RxTest.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RxTest.xcconfig; sourceTree = "<group>"; };
@@ -469,22 +471,20 @@
 		31F93BC7E647D0D2021806296CF59E89 /* RefCountDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RefCountDisposable.swift; path = RxSwift/Disposables/RefCountDisposable.swift; sourceTree = "<group>"; };
 		34E8F0725F629126DB6F582017176D9C /* SynchronizedUnsubscribeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedUnsubscribeType.swift; path = RxSwift/Concurrency/SynchronizedUnsubscribeType.swift; sourceTree = "<group>"; };
 		3517B45D9C3D29D33E054064596EC37D /* Sample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sample.swift; path = RxSwift/Observables/Sample.swift; sourceTree = "<group>"; };
-		37379A91DE98AFA5A17EC9C5EEAD98CE /* Caches.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Caches.swift; path = Sources/Caches.swift; sourceTree = "<group>"; };
 		374A0DAFD6D8FF7495CEBC805719A79A /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
 		390947F0F397720A36AA2256A8B80572 /* SubscriptionDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionDisposable.swift; path = RxSwift/Disposables/SubscriptionDisposable.swift; sourceTree = "<group>"; };
 		39D1EDA30233CDB9F471E3F31C8B71EB /* Stringers.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Stringers.swift; path = Sources/Nimble/Utils/Stringers.swift; sourceTree = "<group>"; };
+		3A0EB6A4389D465A59BCD1881AC9266A /* Fetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Fetcher.swift; sourceTree = "<group>"; };
 		3AA58C96DBD798CAE5DFC169065D36EB /* XCTestObservationCenter+Register.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestObservationCenter+Register.m"; path = "Sources/NimbleObjectiveC/XCTestObservationCenter+Register.m"; sourceTree = "<group>"; };
-		3AB571F432C9F57179967B6111A329D8 /* MapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		3AECE5F1CFACBB7D053E7C0D000BD3A2 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = Sources/Nimble/Utils/Errors.swift; sourceTree = "<group>"; };
 		3C64788EFA087B5960001B6155C636A8 /* WithLatestFrom.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = WithLatestFrom.swift; path = RxSwift/Observables/WithLatestFrom.swift; sourceTree = "<group>"; };
-		3C6C3312968F391BB4825634B645E7DC /* Cache+Salient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Salient.swift"; path = "Sources/Cache+Salient.swift"; sourceTree = "<group>"; };
 		3CDF9BFF6F914D4F8E12C8E5F85922F9 /* Timer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timer.swift; path = RxSwift/Observables/Timer.swift; sourceTree = "<group>"; };
 		3D60A169920697B20C2D24FB59E5AD6E /* RxSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RxSwift-dummy.m"; sourceTree = "<group>"; };
 		3EB2550B5110CA4FB9C6FD26836A6EBC /* Bag+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bag+Rx.swift"; path = "RxSwift/Extensions/Bag+Rx.swift"; sourceTree = "<group>"; };
 		3F1884DFC444445AE3DAE8479FA02472 /* DisposeBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBase.swift; path = RxSwift/Disposables/DisposeBase.swift; sourceTree = "<group>"; };
 		3F2ED5FB51948C30205518DBA2717D88 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Quick.modulemap; sourceTree = "<group>"; };
+		3FC750EC952E121097BF47124F783F5E /* Caches.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Caches.swift; path = Sources/Caches.swift; sourceTree = "<group>"; };
 		403CE64DFF46B860F390BF0D03A422D2 /* ShareReplayScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareReplayScope.swift; path = RxSwift/Observables/ShareReplayScope.swift; sourceTree = "<group>"; };
-		41E67485AB4DE9E206FB2B3D9AE20F9D /* DiskCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCache.swift; sourceTree = "<group>"; };
 		4208096FBE5A3697F4691455C57A52A9 /* PriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorityQueue.swift; path = Platform/DataStructures/PriorityQueue.swift; sourceTree = "<group>"; };
 		427A864D7DB8FDF816621B3A36D25152 /* CurrentTestCaseTracker.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CurrentTestCaseTracker.h; path = Sources/NimbleObjectiveC/CurrentTestCaseTracker.h; sourceTree = "<group>"; };
 		429A78EFD4693FA32211655BDAE214CA /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Quick/DSL/DSL.swift; sourceTree = "<group>"; };
@@ -502,13 +502,13 @@
 		4A90C41F1F0F546F4FE02F94B36DEDBC /* Concat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Concat.swift; path = RxSwift/Observables/Concat.swift; sourceTree = "<group>"; };
 		4AE8D9AB2CF3C93E0C153DEDA2F0AD11 /* DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = DSL.h; path = Sources/NimbleObjectiveC/DSL.h; sourceTree = "<group>"; };
 		4D4AD59559CE5395612189B0ABF91761 /* ObserveOn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserveOn.swift; path = RxSwift/Observables/ObserveOn.swift; sourceTree = "<group>"; };
+		4DBA052779C5A889D0080E10D183D0E0 /* Droste-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Droste-dummy.m"; sourceTree = "<group>"; };
 		528B2C0000D84EC325E9E80E284B37A9 /* SubscribeOn.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscribeOn.swift; path = RxSwift/Observables/SubscribeOn.swift; sourceTree = "<group>"; };
 		52BCCE1CBFDAB8CE24C44B3C3FECFA4E /* ElementAt.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ElementAt.swift; path = RxSwift/Observables/ElementAt.swift; sourceTree = "<group>"; };
 		537A211511A8B2175890320C5F6414D8 /* Timeout.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Timeout.swift; path = RxSwift/Observables/Timeout.swift; sourceTree = "<group>"; };
 		5405B04137B75CB6DFCD07879C98E13F /* mach_excServer.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = mach_excServer.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.h; sourceTree = "<group>"; };
 		54F96F3E7E0E183E02B71545016D7559 /* AsMaybe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsMaybe.swift; path = RxSwift/Observables/AsMaybe.swift; sourceTree = "<group>"; };
 		552550F3F912264E5D073F8893691F88 /* Pods-Example-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Example-frameworks.sh"; sourceTree = "<group>"; };
-		5549902C5D6DE95639A7A3406A2F6C1A /* Droste.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Droste.xcconfig; sourceTree = "<group>"; };
 		55533DD388D650E3B3D03F21B5992570 /* Platform.Darwin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Darwin.swift; path = Platform/Platform.Darwin.swift; sourceTree = "<group>"; };
 		555905450B901A902E8F94CD656E4D97 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = Sources/Quick/Filter.swift; sourceTree = "<group>"; };
 		561ECF42DDB43FE546FAB01764F01B68 /* Producer.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Producer.swift; path = RxSwift/Observables/Producer.swift; sourceTree = "<group>"; };
@@ -516,8 +516,7 @@
 		586FC161DF179CF64CFFD5DBA3E8AA7F /* RxSwift-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RxSwift-umbrella.h"; sourceTree = "<group>"; };
 		599A56FB0BD0A419A50451DADC8E2D60 /* PrimitiveSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PrimitiveSequence.swift; path = RxSwift/Traits/PrimitiveSequence.swift; sourceTree = "<group>"; };
 		59FDB452C5DFA7C19F6658D53AF9F8A3 /* Maybe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Maybe.swift; path = RxSwift/Traits/Maybe.swift; sourceTree = "<group>"; };
-		5AFCEBB293C8636E44263FE7E111A571 /* Fetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = Fetcher.swift; sourceTree = "<group>"; };
-		5C64FDF67FE52ECD279AA4B70989268E /* Droste-Unit-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-resources.sh"; sourceTree = "<group>"; };
+		5C57A36289AA8F980AA9BDB67D172505 /* Cache+ReuseInFlight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ReuseInFlight.swift"; path = "Sources/Cache+ReuseInFlight.swift"; sourceTree = "<group>"; };
 		5CDEDF71C13611D83ACF75918250AB50 /* Optional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = RxSwift/Observables/Optional.swift; sourceTree = "<group>"; };
 		5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		5E71AEC51B010BB3D5AB352ACFBB17BE /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
@@ -526,7 +525,6 @@
 		606025D80E448B904C31D3C61E19A5B2 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		61EAE65D1A37CBBBF2C4FA465BAFD079 /* RaisesException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RaisesException.swift; path = Sources/Nimble/Matchers/RaisesException.swift; sourceTree = "<group>"; };
 		61F77F4B181B08425951C1175E1C5714 /* CombineLatest+Collection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CombineLatest+Collection.swift"; path = "RxSwift/Observables/CombineLatest+Collection.swift"; sourceTree = "<group>"; };
-		62464D8F67EAAB5510738B1565044ADE /* Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cache.swift; path = Sources/Cache.swift; sourceTree = "<group>"; };
 		624AE40A0FCA86E1F3E1D79669BAF589 /* Dematerialize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Dematerialize.swift; path = RxSwift/Observables/Dematerialize.swift; sourceTree = "<group>"; };
 		64299BE07801777F3AD2B98E369C01A5 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
 		647E651ED7B69A270E297A1E2E9976BC /* SchedulerServices+Emulation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SchedulerServices+Emulation.swift"; path = "RxSwift/Schedulers/SchedulerServices+Emulation.swift"; sourceTree = "<group>"; };
@@ -535,30 +533,28 @@
 		664E444158D22087931A52AE7C54FFC7 /* QuickSpec.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpec.h; path = Sources/QuickObjectiveC/QuickSpec.h; sourceTree = "<group>"; };
 		668C823EEE007452668D8D018D5A5EC0 /* Throttle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Throttle.swift; path = RxSwift/Observables/Throttle.swift; sourceTree = "<group>"; };
 		67F89F28CB63883E9DDDECBE8DA2928F /* CwlCatchException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlCatchException.swift; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchException/CwlCatchException.swift; sourceTree = "<group>"; };
-		6863D80AA28BCED142271D15A24F88AE /* Droste-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Droste-dummy.m"; sourceTree = "<group>"; };
+		69320463F3C065B4A59417946DB10E75 /* Droste-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-prefix.pch"; sourceTree = "<group>"; };
 		699118D7DDD5F335E4FB8B17DC0F12D2 /* Pods-Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Example-dummy.m"; sourceTree = "<group>"; };
 		6AFD76D04B1BF859FA77E7363C393977 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C666618A086B6BC13A87EEEC55D5051 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
+		6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForwardRequestOperatorTests.swift; sourceTree = "<group>"; };
 		6DB5546987339D3006C11834A93DA985 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
 		6F4CCF58DC99E09361656CDEB3F969AB /* Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Merge.swift; path = RxSwift/Observables/Merge.swift; sourceTree = "<group>"; };
 		6F89C69F00F905174B0FFBEBF16B23AC /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
 		6FDE67C898D6218C71BCA27B4970A5A1 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
 		6FE326DFA47E41B7CD91300BAA54C629 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70C2CDFAEC61EFDD038EE89B7310CBAD /* StartWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StartWith.swift; path = RxSwift/Observables/StartWith.swift; sourceTree = "<group>"; };
+		70E7A942D578B7C36F0279DB99E36AF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		71E48E4CFF3E795C7F7FC6C05461A260 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
 		71FF73BA6D2BE9A0DD6E2B7FB04382EF /* ScheduledItemType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledItemType.swift; path = RxSwift/Schedulers/Internal/ScheduledItemType.swift; sourceTree = "<group>"; };
 		7212959077D3C9F5654377DDE47A6E15 /* Droste.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Droste.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		729BB400C567E6BEB87A66592000A7F8 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Sources/Extensions.swift; sourceTree = "<group>"; };
 		73030AA83660A13E569AD0113EEB8D17 /* SubjectType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubjectType.swift; path = RxSwift/Subjects/SubjectType.swift; sourceTree = "<group>"; };
 		738135910E0064CB147B94B21A757452 /* Closures.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Closures.swift; path = Sources/Quick/Hooks/Closures.swift; sourceTree = "<group>"; };
 		74E4F5A94A6C5AB2493BE2DA0F47F7A2 /* CwlMachBadInstructionHandler.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlMachBadInstructionHandler.h; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/include/CwlMachBadInstructionHandler.h; sourceTree = "<group>"; };
 		763782B58373E3F28DE2DCD725868E02 /* Contain.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Contain.swift; path = Sources/Nimble/Matchers/Contain.swift; sourceTree = "<group>"; };
 		764D33E23CE6C1111110B04F5CBADADB /* Pods-Example-acknowledgements.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = "Pods-Example-acknowledgements.plist"; sourceTree = "<group>"; };
 		76EA88F354299C8AB82E10AED0726677 /* NMBExceptionCapture.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBExceptionCapture.m; path = Sources/NimbleObjectiveC/NMBExceptionCapture.m; sourceTree = "<group>"; };
-		7707C6E0C7024CF002B0A454F0614716 /* Droste-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-prefix.pch"; sourceTree = "<group>"; };
-		774EDA1B4043F601C2D055BDE59EFACA /* ForwardRequestOperatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForwardRequestOperatorTests.swift; sourceTree = "<group>"; };
 		780C8A5F17502180FDB54824FD3F810D /* Create.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Create.swift; path = RxSwift/Observables/Create.swift; sourceTree = "<group>"; };
-		7859A6745A8C7479D62F97438EE65404 /* ConcurrentDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrentDictionary.swift; sourceTree = "<group>"; };
 		786B0C116AA997C58F9C6A65868A1329 /* World+DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "World+DSL.swift"; path = "Sources/Quick/DSL/World+DSL.swift"; sourceTree = "<group>"; };
 		790D1254BDA12208B89C11C83294C733 /* Event+Equatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Event+Equatable.swift"; path = "RxTest/Event+Equatable.swift"; sourceTree = "<group>"; };
 		79BD64FCED7B504354A3E304CB75C022 /* MatcherProtocols.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatcherProtocols.swift; path = Sources/Nimble/Matchers/MatcherProtocols.swift; sourceTree = "<group>"; };
@@ -566,23 +562,25 @@
 		7A9E11AB03A3F11B7AFB7A0D0F19A0B3 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
 		7AFC985C0C75E35B4A6AE383A847DCC5 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
 		7B9A6A90586B5D6FF6007D3A8CAE078A /* Generate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generate.swift; path = RxSwift/Observables/Generate.swift; sourceTree = "<group>"; };
-		7C51489466E65078F9C8DB22E2C77722 /* CompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionTests.swift; sourceTree = "<group>"; };
 		7D68E41227D7A34AF26E48499DEA8D54 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxTest.framework; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E16CB41EEE80933DC59102A1CF876EA /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
+		7E67A0D7B7413977E91583D48768D24B /* Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cache.swift; path = Sources/Cache.swift; sourceTree = "<group>"; };
 		7E91B5759B010D20E06F6FDC133675F5 /* ReplaySubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReplaySubject.swift; path = RxSwift/Subjects/ReplaySubject.swift; sourceTree = "<group>"; };
 		7EEBC6B47328C37B6BC71434FF08C52B /* VirtualTimeScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeScheduler.swift; path = RxSwift/Schedulers/VirtualTimeScheduler.swift; sourceTree = "<group>"; };
 		7FC31B2AEC5746A85819DD242B506042 /* SingleAsync.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAsync.swift; path = RxSwift/Observables/SingleAsync.swift; sourceTree = "<group>"; };
+		7FE02D88F98AE2E31C5E483D3AD5E674 /* Droste.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Droste.h; path = Sources/Droste.h; sourceTree = "<group>"; };
 		810BCE23B1C947B337E42F6080A31924 /* RxTest-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RxTest-umbrella.h"; sourceTree = "<group>"; };
 		814356EE1E9605CC4A9AC25448622168 /* OperationQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = OperationQueueScheduler.swift; path = RxSwift/Schedulers/OperationQueueScheduler.swift; sourceTree = "<group>"; };
+		8149C0BA1CCDF2D145E8FAA861C9F9F7 /* NSKeyedUnarchiver+Swift.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSKeyedUnarchiver+Swift.m"; path = "Sources/NSKeyedUnarchiver+Swift.m"; sourceTree = "<group>"; };
 		8328E7C0D6403714ECE7338CC9440073 /* CompositeDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeDisposable.swift; path = RxSwift/Disposables/CompositeDisposable.swift; sourceTree = "<group>"; };
-		833DA1A8D2C771CFE16B3550AE6BE063 /* Cache+Compose.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Compose.swift"; path = "Sources/Cache+Compose.swift"; sourceTree = "<group>"; };
 		834ED52643B582A82D56536389F11FA6 /* World+DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "World+DSL.h"; path = "Sources/QuickObjectiveC/DSL/World+DSL.h"; sourceTree = "<group>"; };
 		83EE71F0FE105E79407BC049D2A38772 /* ConnectableObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectableObservableType.swift; path = RxSwift/ConnectableObservableType.swift; sourceTree = "<group>"; };
+		843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionTests.swift; sourceTree = "<group>"; };
 		8565A00AAA29127E3A316E9921DBE732 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		86808D9D54F9F1BCB707742064000F60 /* Cache+Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Switch.swift"; path = "Sources/Cache+Switch.swift"; sourceTree = "<group>"; };
 		889F73266A196B3FE3BB0537221C3009 /* Do.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Do.swift; path = RxSwift/Observables/Do.swift; sourceTree = "<group>"; };
 		88AE06D808F2F25DAA9F9ACDF64372B7 /* Materialize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Materialize.swift; path = RxSwift/Observables/Materialize.swift; sourceTree = "<group>"; };
 		897A823B4CBE909FE21497D7A966D313 /* DispatchQueueConfiguration.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DispatchQueueConfiguration.swift; path = RxSwift/Schedulers/Internal/DispatchQueueConfiguration.swift; sourceTree = "<group>"; };
+		89B07CE9DDAFB2E4903B42ED056052AE /* Droste-Unit-Tests-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-Unit-Tests-prefix.pch"; sourceTree = "<group>"; };
 		8AA059ADFF8022A8F87B7D63FB4614C8 /* ExpectationMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExpectationMessage.swift; path = Sources/Nimble/ExpectationMessage.swift; sourceTree = "<group>"; };
 		8ADDAFE8A1473712231745EE23863851 /* Delay.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Delay.swift; path = RxSwift/Observables/Delay.swift; sourceTree = "<group>"; };
 		8B1D4526BCB1D674C22D81B95CBB4612 /* DSL+Wait.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DSL+Wait.swift"; path = "Sources/Nimble/DSL+Wait.swift"; sourceTree = "<group>"; };
@@ -593,13 +591,14 @@
 		8CAE7C2A80A89C089E3A118C05B6E405 /* TakeWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeWhile.swift; path = RxSwift/Observables/TakeWhile.swift; sourceTree = "<group>"; };
 		8D7DD93F264BC535D061EC8536AE9D8B /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		8D993FEFA0466F8C553B6AAF5A4F255F /* GroupBy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GroupBy.swift; path = RxSwift/Observables/GroupBy.swift; sourceTree = "<group>"; };
+		8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		8EA39E9E71A1FC29AA92E535D177682F /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
-		8EA8699D8B688DA6CC281E609C0014A7 /* ReuseInFlightTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReuseInFlightTests.swift; sourceTree = "<group>"; };
 		8FA7D068830C8E38B73913ABA551D6AA /* TakeLast.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeLast.swift; path = RxSwift/Observables/TakeLast.swift; sourceTree = "<group>"; };
 		90117FABAAFBA5499FEFE1ADD97272AC /* Zip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Zip.swift; path = RxSwift/Observables/Zip.swift; sourceTree = "<group>"; };
 		905B102093BA04370529D8C3EFE29F80 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
+		9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Sources/Extensions.swift; sourceTree = "<group>"; };
 		91E59896EDF05625CF489C9362A4C628 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		9254FA8F7F484E8D845D36DB05B6AB73 /* NSKeyedUnarchiver+Swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSKeyedUnarchiver+Swift.h"; path = "Sources/NSKeyedUnarchiver+Swift.h"; sourceTree = "<group>"; };
+		933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReuseInFlightTests.swift; sourceTree = "<group>"; };
 		935B7F52803202DC339031D5E9057028 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
 		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		95332C62694E7BDC87A33226B19B43C5 /* Reactive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reactive.swift; path = RxSwift/Reactive.swift; sourceTree = "<group>"; };
@@ -607,10 +606,8 @@
 		981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "XCTest+Rx.swift"; path = "RxTest/XCTest+Rx.swift"; sourceTree = "<group>"; };
 		98BFBAE0B2D0F4EDF8D893E80BFB1AE0 /* Using.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Using.swift; path = RxSwift/Observables/Using.swift; sourceTree = "<group>"; };
 		99A3D868BDEAE5EE7CBF2F39D26B8C2B /* CwlCatchException.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = CwlCatchException.h; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/include/CwlCatchException.h; sourceTree = "<group>"; };
-		99D13491843B612FE7764BD718E937AB /* Cache+SkipWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+SkipWhile.swift"; path = "Sources/Cache+SkipWhile.swift"; sourceTree = "<group>"; };
 		9A1F97F9E0F5FA166C24534977251F38 /* XCTestSuite+QuickTestSuiteBuilder.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "XCTestSuite+QuickTestSuiteBuilder.m"; path = "Sources/QuickObjectiveC/XCTestSuite+QuickTestSuiteBuilder.m"; sourceTree = "<group>"; };
 		9AA1890ABEC35BB449F3F5683C6B2425 /* Zip+Collection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Zip+Collection.swift"; path = "RxSwift/Observables/Zip+Collection.swift"; sourceTree = "<group>"; };
-		9B101F8552A16C0B7DD0D36259EC1864 /* Droste-Unit-Tests-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-Unit-Tests-prefix.pch"; sourceTree = "<group>"; };
 		9B5BEDED3CD0D8DDE85A2D11207DD18A /* RecursiveScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecursiveScheduler.swift; path = RxSwift/Schedulers/RecursiveScheduler.swift; sourceTree = "<group>"; };
 		9B6842D0BDC309FDCB3C54B56A18F7BB /* SkipUntil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SkipUntil.swift; path = RxSwift/Observables/SkipUntil.swift; sourceTree = "<group>"; };
 		9BAA4E81E2A603ABE6B8DE1F922F5240 /* ObservableType+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ObservableType+Extensions.swift"; path = "RxSwift/ObservableType+Extensions.swift"; sourceTree = "<group>"; };
@@ -618,12 +615,13 @@
 		9CE0E2A8918AFEAB4B5E7E462139244A /* BooleanDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BooleanDisposable.swift; path = RxSwift/Disposables/BooleanDisposable.swift; sourceTree = "<group>"; };
 		9D1CE888EF874F9D96852F9371F34FEA /* MatchError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MatchError.swift; path = Sources/Nimble/Matchers/MatchError.swift; sourceTree = "<group>"; };
 		9EC43508F7BCF0D0844BC4CB3969BE63 /* InfiniteSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InfiniteSequence.swift; path = Platform/DataStructures/InfiniteSequence.swift; sourceTree = "<group>"; };
-		9F05DAF38986867AA0D0C87E74A24341 /* Cache+ForwardRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ForwardRequest.swift"; path = "Sources/Cache+ForwardRequest.swift"; sourceTree = "<group>"; };
 		9F239EF1F6D92241D56ABA8E4C73B440 /* Map.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Map.swift; path = RxSwift/Observables/Map.swift; sourceTree = "<group>"; };
 		9F466C67722461ED16EEB149A87B6B44 /* AsyncMatcherWrapper.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncMatcherWrapper.swift; path = Sources/Nimble/Matchers/AsyncMatcherWrapper.swift; sourceTree = "<group>"; };
 		A01B9AC2AE3E5160F770D7E24A360B21 /* AnonymousObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousObserver.swift; path = RxSwift/Observers/AnonymousObserver.swift; sourceTree = "<group>"; };
 		A0D122B4BB2E236A54975BD2A0227F3A /* Range.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Range.swift; path = RxSwift/Observables/Range.swift; sourceTree = "<group>"; };
 		A2A73C789D855DEF04139E173F02CE64 /* RxTest-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RxTest-dummy.m"; sourceTree = "<group>"; };
+		A4D65DACD5C31C293EF363C0753AB08F /* Droste-Unit-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-frameworks.sh"; sourceTree = "<group>"; };
+		A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SalientTests.swift; sourceTree = "<group>"; };
 		A58E0F0B1A3B6F28663FC08EB3ACDE78 /* Repeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Repeat.swift; path = RxSwift/Observables/Repeat.swift; sourceTree = "<group>"; };
 		A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
 		A5DF324C6A2B21E73811CBF46C7D33FA /* ObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableType.swift; path = RxSwift/ObservableType.swift; sourceTree = "<group>"; };
@@ -632,12 +630,14 @@
 		A713A3DCE03735AC480D0E3DE0BC5EE1 /* TestSchedulerVirtualTimeConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestSchedulerVirtualTimeConverter.swift; path = RxTest/Schedulers/TestSchedulerVirtualTimeConverter.swift; sourceTree = "<group>"; };
 		A780A534B38DE71C0A2986E58F56EF23 /* AnonymousDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousDisposable.swift; path = RxSwift/Disposables/AnonymousDisposable.swift; sourceTree = "<group>"; };
 		A78833EBBC71D330C71218DBAAA1A4B9 /* RecursiveLock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecursiveLock.swift; path = Platform/RecursiveLock.swift; sourceTree = "<group>"; };
+		A9609E7445AACEDC561F4A22C96B9ACB /* RamCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCache.swift; sourceTree = "<group>"; };
 		AA885A063120E9224890A1BDF6C0E8B9 /* DelaySubscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DelaySubscription.swift; path = RxSwift/Observables/DelaySubscription.swift; sourceTree = "<group>"; };
 		AAABE976D29E82D47711F15A1E106E8B /* Example.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Example.swift; path = Sources/Quick/Example.swift; sourceTree = "<group>"; };
 		AAFFC3B84174FAEC2D251A30EF3A7B52 /* SerialDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDisposable.swift; path = RxSwift/Disposables/SerialDisposable.swift; sourceTree = "<group>"; };
 		AC23D858B2A515A23808022D5F2DD7D7 /* Just.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Just.swift; path = RxSwift/Observables/Just.swift; sourceTree = "<group>"; };
+		AD21BA2BB3EB0AEFF28486AF4D2144D3 /* NetworkFetcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = NetworkFetcher.swift; sourceTree = "<group>"; };
 		AD223D6831D0AC58EDFA33069A37F497 /* Zip+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Zip+arity.swift"; path = "RxSwift/Observables/Zip+arity.swift"; sourceTree = "<group>"; };
-		AE0EA302031C4D488592D0CD692C08DB /* Droste-Unit-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-frameworks.sh"; sourceTree = "<group>"; };
+		AE2EDD7BD06778C4A66DD3B695604617 /* DiskCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCache.swift; sourceTree = "<group>"; };
 		AF17E0B9D2E8682E672520F4CCA1E0C4 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
 		AF9AF554228C539C0AD66F41BFA9CC1C /* Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Debug.swift; path = RxSwift/Observables/Debug.swift; sourceTree = "<group>"; };
 		B0FF8963A749934021EE631E46FA8D10 /* Debounce.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Debounce.swift; path = RxSwift/Observables/Debounce.swift; sourceTree = "<group>"; };
@@ -655,11 +655,11 @@
 		B8FF8CF506C383DA0B139B097FCBADB1 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = RxSwift/Errors.swift; sourceTree = "<group>"; };
 		B9677E9E790094792357AB00A80B5F99 /* Deferred.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deferred.swift; path = RxSwift/Observables/Deferred.swift; sourceTree = "<group>"; };
 		BA43064F9A852B1B6860BCE449DFB169 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
-		BB49F887C65A84BCD16B9793D9071986 /* RetainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetainTests.swift; sourceTree = "<group>"; };
 		BB6F135951F0F23BEDF8068C9C66C27D /* ImmediateSchedulerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImmediateSchedulerType.swift; path = RxSwift/ImmediateSchedulerType.swift; sourceTree = "<group>"; };
 		BD4550F0446F62D284F47CECFFB7CF7C /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
 		BD4A59E727AA546B89DF4132569CD49F /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
 		BE9A2F5B4931E44B6F1B80415CAFE81D /* RxSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RxSwift-prefix.pch"; sourceTree = "<group>"; };
+		BEF0FBAC1203B679D3196FB350EC0F80 /* Droste.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Droste.modulemap; sourceTree = "<group>"; };
 		BF1E96B4FCF763CCF5848F3A04BDEE3C /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
 		C036E198D7FA1F251CE2C2D623B8EC20 /* Deprecated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecated.swift; path = RxTest/Deprecated.swift; sourceTree = "<group>"; };
 		C0D2F869E070B98513E85F2F7921AEAC /* Platform.Linux.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Linux.swift; path = Platform/Platform.Linux.swift; sourceTree = "<group>"; };
@@ -667,28 +667,28 @@
 		C1991D26BBA8ECCC498748FF0B412153 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C20112E2D057B83282A63E76E8FA565D /* SingleAssignmentDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAssignmentDisposable.swift; path = RxSwift/Disposables/SingleAssignmentDisposable.swift; sourceTree = "<group>"; };
 		C2AF68BE3CB6608B515CE233AD8231A2 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
+		C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
+		C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Droste.xcconfig; sourceTree = "<group>"; };
 		C616271A38C3EEDFCB5D35828D794B2F /* Disposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Disposable.swift; path = RxSwift/Disposable.swift; sourceTree = "<group>"; };
 		C656FB4C600D0B66A0CA26EA3CA1C6B6 /* VirtualTimeConverterType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeConverterType.swift; path = RxSwift/Schedulers/VirtualTimeConverterType.swift; sourceTree = "<group>"; };
 		C65B7F488687567D2AD4AEB111AAB8BA /* Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Switch.swift; path = RxSwift/Observables/Switch.swift; sourceTree = "<group>"; };
 		C7181441ED03EE29184C112B38209E46 /* Single.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Single.swift; path = RxSwift/Traits/Single.swift; sourceTree = "<group>"; };
-		C73EC0C10314B30C0A3B90FD210AEDC7 /* RamCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCache.swift; sourceTree = "<group>"; };
 		C7FD76819C1FCE81806064C89E577597 /* Catch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catch.swift; path = RxSwift/Observables/Catch.swift; sourceTree = "<group>"; };
 		C855E1F240198863501B0AD4F112A227 /* LockOwnerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LockOwnerType.swift; path = RxSwift/Concurrency/LockOwnerType.swift; sourceTree = "<group>"; };
 		C86A7256BBD447D4F4C456049B2C581F /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Nimble.modulemap; sourceTree = "<group>"; };
 		C8A6EF2A5694A31A5CDF6AF7E7B00AC8 /* Any+Equatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Any+Equatable.swift"; path = "RxTest/Any+Equatable.swift"; sourceTree = "<group>"; };
 		C9535482AAB6042AA7B9F4708C95A8F1 /* BinaryDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BinaryDisposable.swift; path = RxSwift/Disposables/BinaryDisposable.swift; sourceTree = "<group>"; };
 		C9BDE82371C83FA9AE91B05F77ACAA36 /* Pods-Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Example-umbrella.h"; sourceTree = "<group>"; };
-		C9D59156CA6CF8605BB1CFD83EBFF8F5 /* Droste.unit.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Droste.unit.xcconfig; sourceTree = "<group>"; };
 		C9DEF6971B000CB7E6C2A7079CD93E15 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
 		C9DF150BFE695968F04236FFF189878F /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
 		CB075012E5CF90FC620CE801F83F7E12 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
+		CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SkipWhileTests.swift; sourceTree = "<group>"; };
 		CDFACB25ABE7EF55F68113515C4ED284 /* NopDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NopDisposable.swift; path = RxSwift/Disposables/NopDisposable.swift; sourceTree = "<group>"; };
 		CE18E0BFD2918C0E3F1B5AB26CA5D95F /* Take.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Take.swift; path = RxSwift/Observables/Take.swift; sourceTree = "<group>"; };
-		CF2545CB5297ADED2671AA2BB54FB461 /* SkipWhileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SkipWhileTests.swift; sourceTree = "<group>"; };
-		CF535F52D384FB244CBAF0C56CEC66A9 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		CF9FA296A61F02C71E067B65E060AF9A /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableConvertibleType.swift; path = RxSwift/ObservableConvertibleType.swift; sourceTree = "<group>"; };
 		D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxSwift.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D220738394C885CAE465F0CC85974514 /* Window.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Window.swift; path = RxSwift/Observables/Window.swift; sourceTree = "<group>"; };
+		D2E263E33E01E12E632D7FE81BF1D949 /* Droste-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-umbrella.h"; sourceTree = "<group>"; };
 		D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
 		D3F4C9B8DEFAA1296AC1C58825EA5FBA /* BeLessThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThan.swift; path = Sources/Nimble/Matchers/BeLessThan.swift; sourceTree = "<group>"; };
 		D42A9F7F0C4E92C7D8065D70B4DD6AFE /* Quick-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Quick-dummy.m"; sourceTree = "<group>"; };
@@ -698,9 +698,12 @@
 		D56DA18B320AAC1740C443786FDBB024 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = RxSwift/SwiftSupport/SwiftSupport.swift; sourceTree = "<group>"; };
 		D618449AFC6917EC84F2472DDF576D19 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		D6E1FCBDFE3DD9AF98DAA6B0274E8048 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
+		D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwitchTests.swift; sourceTree = "<group>"; };
 		D8771C43A89854E33143BC1E490E982F /* Reduce.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reduce.swift; path = RxSwift/Observables/Reduce.swift; sourceTree = "<group>"; };
+		D87C44A47BD0F817D12FDE011002A153 /* Cache+Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Switch.swift"; path = "Sources/Cache+Switch.swift"; sourceTree = "<group>"; };
 		D8B189A16C05A14C69624B1D23DEAB3C /* AsyncLock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncLock.swift; path = RxSwift/Concurrency/AsyncLock.swift; sourceTree = "<group>"; };
 		D9223DEE14F4E1C27E97461952AADD3F /* GroupedObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GroupedObservable.swift; path = RxSwift/GroupedObservable.swift; sourceTree = "<group>"; };
+		D9B4773C9426A35F0E66C65A258CF3C7 /* NSKeyedUnarchiver+Swift.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "NSKeyedUnarchiver+Swift.h"; path = "Sources/NSKeyedUnarchiver+Swift.h"; sourceTree = "<group>"; };
 		DA4AEBCEC65280E1F273BF5299035E47 /* ContainElementSatisfying.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ContainElementSatisfying.swift; path = Sources/Nimble/Matchers/ContainElementSatisfying.swift; sourceTree = "<group>"; };
 		DACC17FB90E566827515A71578B2BBA3 /* BeIdenticalTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeIdenticalTo.swift; path = Sources/Nimble/Matchers/BeIdenticalTo.swift; sourceTree = "<group>"; };
 		DB84063868E7FF0FEEACB89F09651C18 /* Bag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bag.swift; path = Platform/DataStructures/Bag.swift; sourceTree = "<group>"; };
@@ -708,6 +711,7 @@
 		DC5812F31B21591951EFBAF40445FFB4 /* QuickConfiguration.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickConfiguration.m; path = Sources/QuickObjectiveC/Configuration/QuickConfiguration.m; sourceTree = "<group>"; };
 		DD067F7995E2B5EBCF8D7991F6C0001D /* Lock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Lock.swift; path = RxSwift/Concurrency/Lock.swift; sourceTree = "<group>"; };
 		DDC071859004A73F33D532D5F42FF61D /* Predicate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Predicate.swift; path = Sources/Nimble/Matchers/Predicate.swift; sourceTree = "<group>"; };
+		DE78517930A474EF59907D69BBFFC104 /* Cache+Salient.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Salient.swift"; path = "Sources/Cache+Salient.swift"; sourceTree = "<group>"; };
 		DE885E75504F9F1BF14039E44FB01500 /* HooksPhase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HooksPhase.swift; path = Sources/Quick/Hooks/HooksPhase.swift; sourceTree = "<group>"; };
 		DF14725542D87B58BC2E9CEFE8368AA5 /* Sink.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sink.swift; path = RxSwift/Observables/Sink.swift; sourceTree = "<group>"; };
 		DF6D2B2E9F09759467884361D3E27E69 /* Functional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Functional.swift; path = Sources/Nimble/Utils/Functional.swift; sourceTree = "<group>"; };
@@ -734,41 +738,48 @@
 		EBE79703A5941E9D88946D36ABB3693F /* RxSwift.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = RxSwift.xcconfig; sourceTree = "<group>"; };
 		ECEF59E38EE96A73E582FC4F0B2CCDE8 /* Recorded.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Recorded.swift; path = RxTest/Recorded.swift; sourceTree = "<group>"; };
 		ED041943DDAED283CAEC5877017A31D3 /* RecursiveLock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RecursiveLock.swift; path = Platform/RecursiveLock.swift; sourceTree = "<group>"; };
-		ED138D8B32B115B3D81476C96343C303 /* Cache+Map.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Map.swift"; path = "Sources/Cache+Map.swift"; sourceTree = "<group>"; };
 		ED1E5D67BF2841C2B6B8A7805B2BFB84 /* ColdObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ColdObservable.swift; path = RxTest/ColdObservable.swift; sourceTree = "<group>"; };
 		EDF67B416E1A9557AC0D4822F59DD545 /* World.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = World.h; path = Sources/QuickObjectiveC/World.h; sourceTree = "<group>"; };
 		EE726664E88FA4A800280396E6EBE7CA /* Disposables.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Disposables.swift; path = RxSwift/Disposables/Disposables.swift; sourceTree = "<group>"; };
 		EFFB74AAA6B2AE8DABF0E88E61E09178 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F099B690CEC2A42B92999FF085FBD9EC /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
 		F0C47A86BF8ACB0C8A501B53C54125E6 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
-		F0FBB7DD7B55AB2DC4E26F3B3246966F /* NSKeyedUnarchiver+Swift.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = "NSKeyedUnarchiver+Swift.m"; path = "Sources/NSKeyedUnarchiver+Swift.m"; sourceTree = "<group>"; };
 		F17F7E7A63184E5A88028E15CD2EAC1A /* Droste-Unit-Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Droste-Unit-Tests"; path = "Droste-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
+		F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetainTests.swift; sourceTree = "<group>"; };
 		F1D1B3DDDC079647155BC0893F747601 /* ObserverType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserverType.swift; path = RxSwift/ObserverType.swift; sourceTree = "<group>"; };
-		F2B1DBBB94EFF1F9CD0DF61DB6468C52 /* Normalize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Normalize.swift; path = Sources/Normalize.swift; sourceTree = "<group>"; };
 		F2B3ACC3A810F1D86386DC66DD864706 /* ConcurrentMainScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentMainScheduler.swift; path = RxSwift/Schedulers/ConcurrentMainScheduler.swift; sourceTree = "<group>"; };
+		F31CCA18D26542150A91E23A17BA3784 /* Droste-Unit-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-resources.sh"; sourceTree = "<group>"; };
 		F40440AE9737515B3DFF94938615CF3C /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		F5167D86BA16961527E0E405A7149A36 /* QuickSpecBase.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = QuickSpecBase.m; path = Sources/QuickSpecBase/QuickSpecBase.m; sourceTree = "<group>"; };
 		F546642C51F69052520612EAA9986664 /* DistinctUntilChanged.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DistinctUntilChanged.swift; path = RxSwift/Observables/DistinctUntilChanged.swift; sourceTree = "<group>"; };
 		F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		F75861FD8178EE58B01ECD63DD21C67D /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
-		F80DAB2FE925D417E88FD10BF200CAD5 /* SalientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SalientTests.swift; sourceTree = "<group>"; };
 		F8590B74B6F82B567F528AF587959257 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Platform/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
+		F93367B5FFE412E86E6141363502F1B4 /* ConcurrentDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrentDictionary.swift; sourceTree = "<group>"; };
+		F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CacheFake.swift; sourceTree = "<group>"; };
 		F97A167AE3E61565ABFF1430236CD2CE /* TestableObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestableObservable.swift; path = RxTest/TestableObservable.swift; sourceTree = "<group>"; };
 		FAD19357A80957099904472A89B7FA0D /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
 		FC3DD92AFC2E510C7B449FED87EDCE01 /* BehaviorSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BehaviorSubject.swift; path = RxSwift/Subjects/BehaviorSubject.swift; sourceTree = "<group>"; };
 		FC4614C36300843A53B2E48EB7750C0F /* BeGreaterThan.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeGreaterThan.swift; path = Sources/Nimble/Matchers/BeGreaterThan.swift; sourceTree = "<group>"; };
-		FC763FCFA189C1D9D227FDDCCA75A22E /* Droste-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-umbrella.h"; sourceTree = "<group>"; };
-		FCC0A3CEAEA336CFBF57500DC81615E9 /* Droste.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Droste.h; path = Sources/Droste.h; sourceTree = "<group>"; };
 		FDCAF829B1C8D3DA675E0C02B226EF70 /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Queue.swift; path = Platform/DataStructures/Queue.swift; sourceTree = "<group>"; };
 		FE29623F1E75DD8832C602FF1FA3FF98 /* SkipWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SkipWhile.swift; path = RxSwift/Observables/SkipWhile.swift; sourceTree = "<group>"; };
 		FE53107134BAB0E0AC7FBF2AA1BC6886 /* ErrorUtility.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ErrorUtility.swift; path = Sources/Quick/ErrorUtility.swift; sourceTree = "<group>"; };
-		FE859F7B131C3DC21704FCF269B10A53 /* DiskCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
 		FEAC9F628163F0D65E621153714528FB /* InvocableScheduledItem.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = InvocableScheduledItem.swift; path = RxSwift/Schedulers/Internal/InvocableScheduledItem.swift; sourceTree = "<group>"; };
+		FF7887A82F93E99219E90E8C6BBA5125 /* Cache+Map.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Map.swift"; path = "Sources/Cache+Map.swift"; sourceTree = "<group>"; };
 		FF8A6753BE6CC5702F03A94774613D01 /* NMBObjCMatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NMBObjCMatcher.swift; path = Sources/Nimble/Adapters/NMBObjCMatcher.swift; sourceTree = "<group>"; };
 		FFD8DA031C932F6A1387C77E541154CC /* RxMutableBox.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxMutableBox.swift; path = RxSwift/RxMutableBox.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1769FEAB6707BD99C0FED437A0AA5CB8 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				73A328FCE4AE1F06C999EB46025609F9 /* Foundation.framework in Frameworks */,
+				461D85757088B19B697B15FDBC06A648 /* RxSwift.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		201DE67D5B046ECB820E5F6F8B1B1399 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -784,23 +795,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				55ED80AC201E95BA04B5DC8CF05F537B /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		5BB4C01C514EDC19E0B0F5FBF4983BC4 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				ED3482ED68B679C4285A26E51263280A /* Foundation.framework in Frameworks */,
-				840A5966B0450CDC793A1BD2289BFBD2 /* RxSwift.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		76A56D77FDF963449D233EA900B39052 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D4CADA0C35E0B6CC281C99915CDAEBA3 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -825,6 +819,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		E399D196CB84CAE0DB048A348961747C /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				04C241623428C470EC9A647F5CCAFF18 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		F7410D6EAF182222F51B4A756C0E721D /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -837,6 +839,54 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		00A5295DD9ECE5D0CF95C40C039D6659 /* Fetchers */ = {
+			isa = PBXGroup;
+			children = (
+				3A0EB6A4389D465A59BCD1881AC9266A /* Fetcher.swift */,
+				AD21BA2BB3EB0AEFF28486AF4D2144D3 /* NetworkFetcher.swift */,
+			);
+			name = Fetchers;
+			path = Sources/Fetchers;
+			sourceTree = "<group>";
+		};
+		0E9D1BA20417C75FD2F7CB91830D244F /* Droste */ = {
+			isa = PBXGroup;
+			children = (
+				7E67A0D7B7413977E91583D48768D24B /* Cache.swift */,
+				20E8BD9801D9F2445DF683A261C21ABA /* Cache+Compose.swift */,
+				2875E2E9FD1B98E7176DDC0B2FAE62E8 /* Cache+Expire.swift */,
+				15ADFD4E713416D860EAA5D3AB70052D /* Cache+ForwardRequest.swift */,
+				FF7887A82F93E99219E90E8C6BBA5125 /* Cache+Map.swift */,
+				5C57A36289AA8F980AA9BDB67D172505 /* Cache+ReuseInFlight.swift */,
+				DE78517930A474EF59907D69BBFFC104 /* Cache+Salient.swift */,
+				02725AA6B05AACA955021B485CF40E0D /* Cache+SkipWhile.swift */,
+				D87C44A47BD0F817D12FDE011002A153 /* Cache+Switch.swift */,
+				3FC750EC952E121097BF47124F783F5E /* Caches.swift */,
+				0CCEEF36C09885B713A3D7560E100904 /* CompositeCache.swift */,
+				7FE02D88F98AE2E31C5E483D3AD5E674 /* Droste.h */,
+				9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */,
+				234C79C3E2DF0647B7127BD9B736D60D /* Normalize.swift */,
+				D9B4773C9426A35F0E66C65A258CF3C7 /* NSKeyedUnarchiver+Swift.h */,
+				8149C0BA1CCDF2D145E8FAA861C9F9F7 /* NSKeyedUnarchiver+Swift.m */,
+				86C2D086A51D41598113855DA5AA0E52 /* Caches */,
+				00A5295DD9ECE5D0CF95C40C039D6659 /* Fetchers */,
+				1488191D420D5F1A7834E9571F0BB616 /* Helpers */,
+				5CE576F56F7C309D31DCE8C8CE94136C /* Support Files */,
+				5173ACD094B782A7D5AE393F1FE84F17 /* Tests */,
+			);
+			name = Droste;
+			path = ../..;
+			sourceTree = "<group>";
+		};
+		1488191D420D5F1A7834E9571F0BB616 /* Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				F93367B5FFE412E86E6141363502F1B4 /* ConcurrentDictionary.swift */,
+			);
+			name = Helpers;
+			path = Sources/Helpers;
+			sourceTree = "<group>";
+		};
 		20AB770E4D4A965B15FB8D4395066874 /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -1099,15 +1149,6 @@
 			path = "../Target Support Files/RxSwift";
 			sourceTree = "<group>";
 		};
-		2E83F6B4527E7530E4F2F22918927A0A /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				FD396418A7710FE84606B36A3C02BCA0 /* Sources */,
-				6AE50518E2FC00C25CBBC849ABF861E4 /* Tests */,
-			);
-			name = Tests;
-			sourceTree = "<group>";
-		};
 		4EF8666932964FEE9170D2F75F53820A /* Pods */ = {
 			isa = PBXGroup;
 			children = (
@@ -1119,41 +1160,39 @@
 			name = Pods;
 			sourceTree = "<group>";
 		};
+		5173ACD094B782A7D5AE393F1FE84F17 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				C99619C8783FD836C22CB497FD15FBFF /* Sources */,
+				FC9BEFA41E09286ACFB0C8B11E6008AF /* Tests */,
+			);
+			name = Tests;
+			sourceTree = "<group>";
+		};
+		5CE576F56F7C309D31DCE8C8CE94136C /* Support Files */ = {
+			isa = PBXGroup;
+			children = (
+				BEF0FBAC1203B679D3196FB350EC0F80 /* Droste.modulemap */,
+				C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */,
+				4DBA052779C5A889D0080E10D183D0E0 /* Droste-dummy.m */,
+				69320463F3C065B4A59417946DB10E75 /* Droste-prefix.pch */,
+				D2E263E33E01E12E632D7FE81BF1D949 /* Droste-umbrella.h */,
+				A4D65DACD5C31C293EF363C0753AB08F /* Droste-Unit-Tests-frameworks.sh */,
+				89B07CE9DDAFB2E4903B42ED056052AE /* Droste-Unit-Tests-prefix.pch */,
+				F31CCA18D26542150A91E23A17BA3784 /* Droste-Unit-Tests-resources.sh */,
+				22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */,
+				70E7A942D578B7C36F0279DB99E36AF0 /* Info.plist */,
+			);
+			name = "Support Files";
+			path = "Example/Pods/Target Support Files/Droste";
+			sourceTree = "<group>";
+		};
 		6A4F6A14E3FB951290E4531728B7A461 /* Targets Support Files */ = {
 			isa = PBXGroup;
 			children = (
 				FE9811ABEB5931E154211FCA14B78350 /* Pods-Example */,
 			);
 			name = "Targets Support Files";
-			sourceTree = "<group>";
-		};
-		6AE50518E2FC00C25CBBC849ABF861E4 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				06D3297663817AF304B6B70CABC112D0 /* CacheFake.swift */,
-				7C51489466E65078F9C8DB22E2C77722 /* CompositionTests.swift */,
-				FE859F7B131C3DC21704FCF269B10A53 /* DiskCacheTests.swift */,
-				774EDA1B4043F601C2D055BDE59EFACA /* ForwardRequestOperatorTests.swift */,
-				3AB571F432C9F57179967B6111A329D8 /* MapTests.swift */,
-				1C9788D832534414037D108368A8A708 /* RamCacheTests.swift */,
-				BB49F887C65A84BCD16B9793D9071986 /* RetainTests.swift */,
-				8EA8699D8B688DA6CC281E609C0014A7 /* ReuseInFlightTests.swift */,
-				F80DAB2FE925D417E88FD10BF200CAD5 /* SalientTests.swift */,
-				CF2545CB5297ADED2671AA2BB54FB461 /* SkipWhileTests.swift */,
-				198D8EE76D918CCDC8303E28606BF574 /* SwitchTests.swift */,
-			);
-			name = Tests;
-			path = Tests;
-			sourceTree = "<group>";
-		};
-		6CC62267CA98FCAC75A622C0523C2164 /* Caches */ = {
-			isa = PBXGroup;
-			children = (
-				41E67485AB4DE9E206FB2B3D9AE20F9D /* DiskCache.swift */,
-				C73EC0C10314B30C0A3B90FD210AEDC7 /* RamCache.swift */,
-			);
-			name = Caches;
-			path = Sources/Caches;
 			sourceTree = "<group>";
 		};
 		6E1D3F899F37CDD6F95A5C602CB93B05 /* RxTest */ = {
@@ -1195,16 +1234,34 @@
 			name = iOS;
 			sourceTree = "<group>";
 		};
+		71F8E6FFC0BA4AA05AD88B136938F895 /* Development Pods */ = {
+			isa = PBXGroup;
+			children = (
+				0E9D1BA20417C75FD2F7CB91830D244F /* Droste */,
+			);
+			name = "Development Pods";
+			sourceTree = "<group>";
+		};
 		7DB346D0F39D3F0E887471402A8071AB = {
 			isa = PBXGroup;
 			children = (
 				93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */,
-				D08A420565E97256B8C2292211F11369 /* Development Pods */,
+				71F8E6FFC0BA4AA05AD88B136938F895 /* Development Pods */,
 				20AB770E4D4A965B15FB8D4395066874 /* Frameworks */,
 				4EF8666932964FEE9170D2F75F53820A /* Pods */,
 				D1D64EC400620608537E1A15682BB148 /* Products */,
 				6A4F6A14E3FB951290E4531728B7A461 /* Targets Support Files */,
 			);
+			sourceTree = "<group>";
+		};
+		86C2D086A51D41598113855DA5AA0E52 /* Caches */ = {
+			isa = PBXGroup;
+			children = (
+				AE2EDD7BD06778C4A66DD3B695604617 /* DiskCache.swift */,
+				A9609E7445AACEDC561F4A22C96B9ACB /* RamCache.swift */,
+			);
+			name = Caches;
+			path = Sources/Caches;
 			sourceTree = "<group>";
 		};
 		8B2F60C18D76EB4C2A8BDEB31F64BD9D /* Support Files */ = {
@@ -1219,16 +1276,6 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Quick";
-			sourceTree = "<group>";
-		};
-		9064652275E0909AAB358C1096D1EFA2 /* Fetchers */ = {
-			isa = PBXGroup;
-			children = (
-				5AFCEBB293C8636E44263FE7E111A571 /* Fetcher.swift */,
-				0331E71197D06F4AB4BF9FD768A1CD94 /* NetworkFetcher.swift */,
-			);
-			name = Fetchers;
-			path = Sources/Fetchers;
 			sourceTree = "<group>";
 		};
 		9A5BD83E700EFADABBCC450BAE1AFC21 /* Quick */ = {
@@ -1300,21 +1347,12 @@
 			path = "../Target Support Files/Nimble";
 			sourceTree = "<group>";
 		};
-		D08A420565E97256B8C2292211F11369 /* Development Pods */ = {
+		C99619C8783FD836C22CB497FD15FBFF /* Sources */ = {
 			isa = PBXGroup;
 			children = (
-				EFBFB77242DE7B9C8CFD4D5B63A7B8AA /* Droste */,
 			);
-			name = "Development Pods";
-			sourceTree = "<group>";
-		};
-		D12F946E07EFACE341E4D30CCFFF92C6 /* Helpers */ = {
-			isa = PBXGroup;
-			children = (
-				7859A6745A8C7479D62F97438EE65404 /* ConcurrentDictionary.swift */,
-			);
-			name = Helpers;
-			path = Sources/Helpers;
+			name = Sources;
+			path = Sources;
 			sourceTree = "<group>";
 		};
 		D1D64EC400620608537E1A15682BB148 /* Products */ = {
@@ -1331,58 +1369,23 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		D6657ED7B253EC1E08EFFDBD4D9AC310 /* Support Files */ = {
+		FC9BEFA41E09286ACFB0C8B11E6008AF /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				1C95587B4613F96050C6DDFA23317AAE /* Droste.modulemap */,
-				5549902C5D6DE95639A7A3406A2F6C1A /* Droste.xcconfig */,
-				6863D80AA28BCED142271D15A24F88AE /* Droste-dummy.m */,
-				7707C6E0C7024CF002B0A454F0614716 /* Droste-prefix.pch */,
-				FC763FCFA189C1D9D227FDDCCA75A22E /* Droste-umbrella.h */,
-				AE0EA302031C4D488592D0CD692C08DB /* Droste-Unit-Tests-frameworks.sh */,
-				9B101F8552A16C0B7DD0D36259EC1864 /* Droste-Unit-Tests-prefix.pch */,
-				5C64FDF67FE52ECD279AA4B70989268E /* Droste-Unit-Tests-resources.sh */,
-				C9D59156CA6CF8605BB1CFD83EBFF8F5 /* Droste.unit.xcconfig */,
-				CF535F52D384FB244CBAF0C56CEC66A9 /* Info.plist */,
+				F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */,
+				843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */,
+				C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */,
+				6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */,
+				8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */,
+				070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */,
+				F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */,
+				933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */,
+				A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */,
+				CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */,
+				D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */,
 			);
-			name = "Support Files";
-			path = "Example/Pods/Target Support Files/Droste";
-			sourceTree = "<group>";
-		};
-		EFBFB77242DE7B9C8CFD4D5B63A7B8AA /* Droste */ = {
-			isa = PBXGroup;
-			children = (
-				62464D8F67EAAB5510738B1565044ADE /* Cache.swift */,
-				833DA1A8D2C771CFE16B3550AE6BE063 /* Cache+Compose.swift */,
-				9F05DAF38986867AA0D0C87E74A24341 /* Cache+ForwardRequest.swift */,
-				ED138D8B32B115B3D81476C96343C303 /* Cache+Map.swift */,
-				0FE71F3465244B868B47B67787C3FE71 /* Cache+ReuseInFlight.swift */,
-				3C6C3312968F391BB4825634B645E7DC /* Cache+Salient.swift */,
-				99D13491843B612FE7764BD718E937AB /* Cache+SkipWhile.swift */,
-				86808D9D54F9F1BCB707742064000F60 /* Cache+Switch.swift */,
-				37379A91DE98AFA5A17EC9C5EEAD98CE /* Caches.swift */,
-				19931B0C3BEFF5E9ED997DD64BC3F996 /* CompositeCache.swift */,
-				FCC0A3CEAEA336CFBF57500DC81615E9 /* Droste.h */,
-				729BB400C567E6BEB87A66592000A7F8 /* Extensions.swift */,
-				F2B1DBBB94EFF1F9CD0DF61DB6468C52 /* Normalize.swift */,
-				9254FA8F7F484E8D845D36DB05B6AB73 /* NSKeyedUnarchiver+Swift.h */,
-				F0FBB7DD7B55AB2DC4E26F3B3246966F /* NSKeyedUnarchiver+Swift.m */,
-				6CC62267CA98FCAC75A622C0523C2164 /* Caches */,
-				9064652275E0909AAB358C1096D1EFA2 /* Fetchers */,
-				D12F946E07EFACE341E4D30CCFFF92C6 /* Helpers */,
-				D6657ED7B253EC1E08EFFDBD4D9AC310 /* Support Files */,
-				2E83F6B4527E7530E4F2F22918927A0A /* Tests */,
-			);
-			name = Droste;
-			path = ../..;
-			sourceTree = "<group>";
-		};
-		FD396418A7710FE84606B36A3C02BCA0 /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Sources;
-			path = Sources;
+			name = Tests;
+			path = Tests;
 			sourceTree = "<group>";
 		};
 		FE9811ABEB5931E154211FCA14B78350 /* Pods-Example */ = {
@@ -1423,21 +1426,11 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		431F90E57BC882572388F5E9CABE130B /* Headers */ = {
+		1D34EA1D1D4A62B517EFF452B1460325 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				33CBE40C7924C67E4548605D8ABB4356 /* RxSwift-umbrella.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		60AABDA0EA0E9DF5C9CE255BC0DDFE99 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				CBF543BC6E297BEEA334826F14815A0E /* Droste-umbrella.h in Headers */,
-				3AB9EF6AF3C144719170FD525495D371 /* Droste.h in Headers */,
-				44C8ADB25DDB31DCAB38EF9C4EE2BC88 /* NSKeyedUnarchiver+Swift.h in Headers */,
+				613A85087648D76248BDDC254B4EC8D6 /* RxSwift-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1461,6 +1454,16 @@
 			buildActionMask = 2147483647;
 			files = (
 				08EDDF54E6AAF16AEA5D116786EB9D70 /* RxTest-umbrella.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		9813CEE2486055DA6420308E547E51F7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				F2B56C38AC34F501253BD69ACD625D93 /* Droste-umbrella.h in Headers */,
+				095331F60096F4DCE71960DFFD33935A /* Droste.h in Headers */,
+				F0AE3DA6E950970BCE1C5DEDF3551A01 /* NSKeyedUnarchiver+Swift.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1515,6 +1518,24 @@
 			productReference = F17F7E7A63184E5A88028E15CD2EAC1A /* Droste-Unit-Tests */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 316AD90DA728FE2E1EDD8B726E24DFD0 /* Build configuration list for PBXNativeTarget "Droste" */;
+			buildPhases = (
+				A33DE76A825484272493B561D8D6E68C /* Sources */,
+				1769FEAB6707BD99C0FED437A0AA5CB8 /* Frameworks */,
+				9813CEE2486055DA6420308E547E51F7 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				0869ABA0765D7174E9605CDC7F5DDDBF /* PBXTargetDependency */,
+			);
+			name = Droste;
+			productName = Droste;
+			productReference = B20D338C109FC605D3EDC5233AC69F1A /* Droste.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		6F8992968BD73DAA9694DFC7C277FDC0 /* Pods-Example */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = CE9D1A9946E7F1D62FEFE9AE5CDD83EF /* Build configuration list for PBXNativeTarget "Pods-Example" */;
@@ -1532,6 +1553,23 @@
 			name = "Pods-Example";
 			productName = "Pods-Example";
 			productReference = DFF18FC4C0C1A5B0FFDBCFB18A5AC2F8 /* Pods_Example.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = BB1A0E3BE9000EBB8AC344A6C12965B0 /* Build configuration list for PBXNativeTarget "RxSwift" */;
+			buildPhases = (
+				7B345CCC77C4EDB9624B0B30463BAFAD /* Sources */,
+				E399D196CB84CAE0DB048A348961747C /* Frameworks */,
+				1D34EA1D1D4A62B517EFF452B1460325 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = RxSwift;
+			productName = RxSwift;
+			productReference = D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		9B3375A14D46317B1F3AE269C44D7F8A /* RxTest */ = {
@@ -1569,41 +1607,6 @@
 			productReference = 1A82A5891550F89601465A5DE5BB7434 /* Quick.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 959C2E5C18F2254AEEA1EE838E626A8F /* Build configuration list for PBXNativeTarget "RxSwift" */;
-			buildPhases = (
-				3BF7066EBA120716BE6B3E91C809CEF5 /* Sources */,
-				76A56D77FDF963449D233EA900B39052 /* Frameworks */,
-				431F90E57BC882572388F5E9CABE130B /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = RxSwift;
-			productName = RxSwift;
-			productReference = D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		DD99D696E5267913E4B38DE2607FBAF8 /* Droste */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 803472A2C9FF67F95DEA8E708E6F0724 /* Build configuration list for PBXNativeTarget "Droste" */;
-			buildPhases = (
-				ED1FFFA272B912501FEA6C21C152DE9A /* Sources */,
-				5BB4C01C514EDC19E0B0F5FBF4983BC4 /* Frameworks */,
-				60AABDA0EA0E9DF5C9CE255BC0DDFE99 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				DD990774DE2663FAEFFB8CB0F8BD1BD1 /* PBXTargetDependency */,
-			);
-			name = Droste;
-			productName = Droste;
-			productReference = B20D338C109FC605D3EDC5233AC69F1A /* Droste.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 /* End PBXNativeTarget section */
 
 /* Begin PBXProject section */
@@ -1625,12 +1628,12 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				DD99D696E5267913E4B38DE2607FBAF8 /* Droste */,
+				6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */,
 				5A81B967EC67244952442AB181DE8E19 /* Droste-Unit-Tests */,
 				20FA9B910D332A1809C9C2C423887904 /* Nimble */,
 				6F8992968BD73DAA9694DFC7C277FDC0 /* Pods-Example */,
 				A7635A015B61D26AF6E4B111CB69BDEF /* Quick */,
-				C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */,
+				70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */,
 				9B3375A14D46317B1F3AE269C44D7F8A /* RxTest */,
 			);
 		};
@@ -1730,162 +1733,6 @@
 				3E5F7F47A7092E1944CF1CD29EFD51F5 /* SalientTests.swift in Sources */,
 				ADBE46FFD944AE1D82BA9B45427182EF /* SkipWhileTests.swift in Sources */,
 				D1E2FA965DB95066E3ECC9F2D90B2773 /* SwitchTests.swift in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3BF7066EBA120716BE6B3E91C809CEF5 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				AD51675635B8745A1A0C021F1328E63D /* AddRef.swift in Sources */,
-				423689DBD345F053476DD6F19D3C92D0 /* Amb.swift in Sources */,
-				4538AAC730F9D848CB2B0DDA48AF1E22 /* AnonymousDisposable.swift in Sources */,
-				D988EF541FF163B7211000F207E6BAF5 /* AnonymousObserver.swift in Sources */,
-				08B139B94CC2319B08F8CEA90275697E /* AnyObserver.swift in Sources */,
-				BA1AE78FEA0A72A6466E4E1C9C0E8479 /* AsMaybe.swift in Sources */,
-				4C6BFBEFE87A84B6E23FB0DAEC2F0936 /* AsSingle.swift in Sources */,
-				3B0FDBC1D1913D386F4B530D5BE27551 /* AsyncLock.swift in Sources */,
-				40FB69139987D5CAFC639BBB8E08A8D9 /* AsyncSubject.swift in Sources */,
-				C453A503755C9EC292831E24357B4F0F /* Bag+Rx.swift in Sources */,
-				78E82035544790B21485DA869D2DF65C /* Bag.swift in Sources */,
-				3724AEA33A5FED8D21001F5BE45206AE /* BehaviorSubject.swift in Sources */,
-				4397BF2D949A88D04E768F33E36FB14D /* BinaryDisposable.swift in Sources */,
-				CC4A3C05831E7277B810E77ED26DD7B6 /* BooleanDisposable.swift in Sources */,
-				886CAE18B7BE1FFC66877F770A137B2F /* Buffer.swift in Sources */,
-				A52D59AF157A7CAC42C346D5E3F9C7A6 /* Cancelable.swift in Sources */,
-				CEBBCA1BDE73EF3BB0D808489A089D67 /* Catch.swift in Sources */,
-				97DE254F328F62E9C18FD4D288591858 /* CombineLatest+arity.swift in Sources */,
-				D758FBEF9A6870F8238255833527F80C /* CombineLatest+Collection.swift in Sources */,
-				5BD45FB9FAF04108A7FDF91BCF51FF46 /* CombineLatest.swift in Sources */,
-				DA581B2FBE4E23E6224202323B950CB4 /* Completable+AndThen.swift in Sources */,
-				8A4CC7A59C26F073C8E4FF501CEEA40B /* Completable.swift in Sources */,
-				AA5A068949E7731A8A2523D2A432EB45 /* CompositeDisposable.swift in Sources */,
-				BAF99DF586BDB43C112A0C19FBE2308E /* Concat.swift in Sources */,
-				DAE250AA7A17528D8EDE26BFC3D14D71 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
-				C442644A32C247F67063C6609348A980 /* ConcurrentMainScheduler.swift in Sources */,
-				03324D909AAD2631F09516516E6FAFF9 /* ConnectableObservableType.swift in Sources */,
-				0E8572AE94BAB3BEF73F4EB7896C4135 /* Create.swift in Sources */,
-				4E2954EFC7CA603552B4E728302B50D8 /* CurrentThreadScheduler.swift in Sources */,
-				3D46E00C07A49E4E1A6DADF32F182C5F /* Debounce.swift in Sources */,
-				99DBDB52508B157BF3F68F0FD55FD64C /* Debug.swift in Sources */,
-				99BB7DD86B9CAE3C91E033705B158FE7 /* DefaultIfEmpty.swift in Sources */,
-				78978857E05FC2EEDBE5A79C098B8D40 /* Deferred.swift in Sources */,
-				F4A4FA47C7EFC8E3F2995BF42C3EE6CF /* Delay.swift in Sources */,
-				384AC1469BB3C99889312CDFF0D3A4A4 /* DelaySubscription.swift in Sources */,
-				6A6F2F9155AE191FEB5CC2D2A70257B9 /* Dematerialize.swift in Sources */,
-				77FA2E279F8B9F30B7A5E79E4CFC5CA9 /* Deprecated.swift in Sources */,
-				85ECBAC0D005D728D10EA42DCE71A7AE /* DispatchQueue+Extensions.swift in Sources */,
-				E259564A33E97FCDE260E5261F7EBB75 /* DispatchQueueConfiguration.swift in Sources */,
-				1CB32BFBEC07E91745CBD6B4BB601736 /* Disposable.swift in Sources */,
-				D293BABD4ACF596061B9C47C0E40CA26 /* Disposables.swift in Sources */,
-				2E1AD718C49F0FCAFB24BAB1A2F38A5F /* DisposeBag.swift in Sources */,
-				965E8B431BD4339D96A545827E348A02 /* DisposeBase.swift in Sources */,
-				33F7A5BF76F0D64CCC8F058943572F4D /* DistinctUntilChanged.swift in Sources */,
-				7D45240FD1FA308940F31DA57475D69E /* Do.swift in Sources */,
-				4EFE4AF4B998C54ED2CFF742F436F8BD /* ElementAt.swift in Sources */,
-				E017FEEDBC4EFA974EDBFA4831CAC7A5 /* Empty.swift in Sources */,
-				062C572892FC95269637D9E6F07AB644 /* Enumerated.swift in Sources */,
-				93D5AE24FFC003B522B6CBCC8BA908F6 /* Error.swift in Sources */,
-				BEB766652E3259FB68FC74B7E39FFE0A /* Errors.swift in Sources */,
-				46E14A903045717CA9B8963F408638F4 /* Event.swift in Sources */,
-				E4408EC7783D0BA7B2D2EE55D38482C7 /* Filter.swift in Sources */,
-				0549D038F1D25A4F25A6BA9FDCA3B140 /* First.swift in Sources */,
-				CC3606C5BF3322C22DE176521CF61AD0 /* Generate.swift in Sources */,
-				4DB056FDF08265D454BAA1226B9BF3D5 /* GroupBy.swift in Sources */,
-				A4DF1E0D85844B0822237036EBCAD337 /* GroupedObservable.swift in Sources */,
-				3BB21D2D64998A64929CB1914BAD003B /* HistoricalScheduler.swift in Sources */,
-				D0E6889059151B7696884B3CD0921C21 /* HistoricalSchedulerTimeConverter.swift in Sources */,
-				938F21910297686E2BB6385014868190 /* ImmediateSchedulerType.swift in Sources */,
-				CE734BE34EE2348D771A827FCB24B875 /* InfiniteSequence.swift in Sources */,
-				648FB53B11B9D8147E4E73DCEF05AC97 /* InvocableScheduledItem.swift in Sources */,
-				1FDC8938CFA792381A76A0EE3EB198E4 /* InvocableType.swift in Sources */,
-				49DBF5631CCE670375126A5EEE8D922E /* Just.swift in Sources */,
-				88783D2F9CD69110A4ABEC2031CB56C5 /* Lock.swift in Sources */,
-				5E48E67B2ABD87C14F5D3E57906B551E /* LockOwnerType.swift in Sources */,
-				079A50DE3F6FD0314754611A959C6834 /* MainScheduler.swift in Sources */,
-				58927D6F2EB4834B8E0F96FC15616800 /* Map.swift in Sources */,
-				67ED2FD4423F3661616B3AFFD8EDBFD7 /* Materialize.swift in Sources */,
-				FAF3E5B81AA669C708533C8F01F7C14C /* Maybe.swift in Sources */,
-				F38978F25150F1455F75BED67388195A /* Merge.swift in Sources */,
-				9EEDBA8ECFB03AB675FA2683EB955D94 /* Multicast.swift in Sources */,
-				3C4477167645153A119029EB55437871 /* Never.swift in Sources */,
-				19781E48735064957D4102750EAF5B19 /* NopDisposable.swift in Sources */,
-				9E948C88896507C1BCA4ED24E3B440C3 /* Observable.swift in Sources */,
-				36CB65BF1273A7BCAC149538E75DB249 /* ObservableConvertibleType.swift in Sources */,
-				7808094D34E63594E95CCEE856B9D50C /* ObservableType+Extensions.swift in Sources */,
-				3C40E5C8B360F1F81100630D5B3B5101 /* ObservableType+PrimitiveSequence.swift in Sources */,
-				9AA4A43B2ECA66A6F5D500A76E942A84 /* ObservableType.swift in Sources */,
-				1FD90C9AFE89C26BA26F6DB48A889D74 /* ObserveOn.swift in Sources */,
-				75551268340656C9AF7D8A8C49B35B67 /* ObserverBase.swift in Sources */,
-				6EF5B9089F9C4E2D280B7FFFE03CEEA4 /* ObserverType.swift in Sources */,
-				AA34E372CFB45D35141B662D43E2B1CA /* OperationQueueScheduler.swift in Sources */,
-				A0484841A82039EE20C7D2692E9FF443 /* Optional.swift in Sources */,
-				4406995930AF3FB0D79EA917A1D0CDBE /* Platform.Darwin.swift in Sources */,
-				535B724C0A1EECF6067F755D533DCB9B /* Platform.Linux.swift in Sources */,
-				4A72FD8305588AE73A35CA46DD6F15C2 /* PrimitiveSequence+Zip+arity.swift in Sources */,
-				40F064F9753E41EB1F13609E650ED8AF /* PrimitiveSequence.swift in Sources */,
-				830AA32E1370EC17E4BA11982F72B59E /* PriorityQueue.swift in Sources */,
-				637B13D9A814E7093EA737CA00CC7E55 /* Producer.swift in Sources */,
-				D015517ABDB5B56ACE6BC9B944FE2601 /* PublishSubject.swift in Sources */,
-				388964141715E092BE47496FA0472362 /* Queue.swift in Sources */,
-				296019E670AEBDCD622CF9060226C268 /* Range.swift in Sources */,
-				9560906F63262392EFA38ED2CB3B8199 /* Reactive.swift in Sources */,
-				5CDB25EC8ABFC26513B4DFE9072CC7F0 /* RecursiveLock.swift in Sources */,
-				9A9C038CD72CF56CAC434ED102ECD494 /* RecursiveScheduler.swift in Sources */,
-				1EC7B737F053FEE4BFA8F779C828A934 /* Reduce.swift in Sources */,
-				6045F6B84465435FDA51BE8ED3D5595F /* RefCountDisposable.swift in Sources */,
-				A52D7659626B9CEAD5C14DD4B4149A2E /* Repeat.swift in Sources */,
-				9DB7DFC45C14E75960D53BBAA0E79975 /* ReplaySubject.swift in Sources */,
-				E72DE8266B35092258B18D7B22B64566 /* RetryWhen.swift in Sources */,
-				ED1390662B68932D6E56E4237A1DF755 /* Rx.swift in Sources */,
-				ED99D8FB1BA3D24666EF6436DF54951E /* RxMutableBox.swift in Sources */,
-				177C926198AABA019627F8C5980B7954 /* RxSwift-dummy.m in Sources */,
-				D2D9E870761EA21B32DB45DADED99D2C /* Sample.swift in Sources */,
-				E91D5333B1BFFC78AC1D942B9CCEA0C5 /* Scan.swift in Sources */,
-				D94F2290ED80DA41317503A900341AE3 /* ScheduledDisposable.swift in Sources */,
-				192C604745F0C0A389CAFC6CE8622170 /* ScheduledItem.swift in Sources */,
-				BC6E55CA5C9295B2756FAB91E56033F4 /* ScheduledItemType.swift in Sources */,
-				429B952FB5B9DB060690D0DD499A1DE2 /* SchedulerServices+Emulation.swift in Sources */,
-				6ABE9D236633C2CB157257F510C519E2 /* SchedulerType.swift in Sources */,
-				08BB725639DE88D7F64BC84F3CF1AFA1 /* Sequence.swift in Sources */,
-				AFDD57288C4B2706C61738929D23D8A1 /* SerialDispatchQueueScheduler.swift in Sources */,
-				A878734D3B6D3901860088A3E5C3254A /* SerialDisposable.swift in Sources */,
-				620AFB4970ED7996C38C781EE5104280 /* ShareReplayScope.swift in Sources */,
-				94425C205FF57485B9D917947F7629B4 /* Single.swift in Sources */,
-				06AE843EE537E5C65FC24B0BEABAE323 /* SingleAssignmentDisposable.swift in Sources */,
-				9BDF141D2C1AF32142212C4393F47BB3 /* SingleAsync.swift in Sources */,
-				08196B9695D5E43B036B5D9DA0255D7B /* Sink.swift in Sources */,
-				2ECB31673D74715153B0A9C288D91E32 /* Skip.swift in Sources */,
-				1B00991A7B42C3947404F6D05BC4A72B /* SkipUntil.swift in Sources */,
-				34B5AD045CA98D267E7E9F34D2A5F684 /* SkipWhile.swift in Sources */,
-				3AD7FCD8C56B34C08175CFE1914BE3D1 /* StartWith.swift in Sources */,
-				15DFAD42206FA56569E2C90ED08119D5 /* String+Rx.swift in Sources */,
-				5865C7C727539B4FE606B6525CAEC927 /* SubjectType.swift in Sources */,
-				6981F42A9D6AEA3C59CD6606C1F6A724 /* SubscribeOn.swift in Sources */,
-				BFE2AE907B3DFEA669E43ED77E6115B4 /* SubscriptionDisposable.swift in Sources */,
-				335A4D1631C8F841383004FB6B9D9CC0 /* SwiftSupport.swift in Sources */,
-				C86420D4E85D7723D8D194C181B851C5 /* Switch.swift in Sources */,
-				20BBD8E5464B6A90F85438A06AE2E814 /* SwitchIfEmpty.swift in Sources */,
-				54D134BAEC188454E17A48D19470B525 /* SynchronizedDisposeType.swift in Sources */,
-				1C123C04FA1B7C35E1B2C810FB3E90C8 /* SynchronizedOnType.swift in Sources */,
-				AFE8E7890E0E5EF2228F52BBE6D441C1 /* SynchronizedUnsubscribeType.swift in Sources */,
-				BB55CE309B316A92FC2DC8589432BF0D /* TailRecursiveSink.swift in Sources */,
-				DCCCB6B0197B7AE37E472D28BC81D08B /* Take.swift in Sources */,
-				A83CF92242521C88CA0D0551D4C33A06 /* TakeLast.swift in Sources */,
-				70B1B49D4F6AC4278B949E43B1A71C99 /* TakeUntil.swift in Sources */,
-				95240B8549B77F843BC647FE6F62CF85 /* TakeWhile.swift in Sources */,
-				0AB4790C253E0AB1650CC1898FCC2021 /* Throttle.swift in Sources */,
-				0899DBA1BA66BF451A8A9D31FA682A7F /* Timeout.swift in Sources */,
-				9DFC45C404CABB05A60B2BA7B7D89814 /* Timer.swift in Sources */,
-				3D3CFC9B67AA72BC58C7FF20E3546E3E /* ToArray.swift in Sources */,
-				27FC89ECC2417B07D6CD80B9A48BF277 /* Using.swift in Sources */,
-				58C329E03AF257EAD5023AEC3F475AAC /* VirtualTimeConverterType.swift in Sources */,
-				104C862C26CF08775C3569158DBA32E2 /* VirtualTimeScheduler.swift in Sources */,
-				3419A58633B56E6BA25032332DB40015 /* Window.swift in Sources */,
-				018556E238B9E73188305B13DFE0308B /* WithLatestFrom.swift in Sources */,
-				7908DE2BA5E510C1AB9322C1906CD05A /* Zip+arity.swift in Sources */,
-				0FA3681734FA50C3FF4CA05F5B736CC5 /* Zip+Collection.swift in Sources */,
-				B9F5EC8B7FEC3F9063FBCA48BCAB96DD /* Zip.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1994,35 +1841,198 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		ED1FFFA272B912501FEA6C21C152DE9A /* Sources */ = {
+		7B345CCC77C4EDB9624B0B30463BAFAD /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				2219DF8604BDD04E1BF575D5C049E4E1 /* Cache+Compose.swift in Sources */,
-				9B0FF4D8EB4EB068FF25EDF566BE5A1D /* Cache+ForwardRequest.swift in Sources */,
-				92DB1648024B40ABA39F9D6B6E121ECA /* Cache+Map.swift in Sources */,
-				8B85776BFF24580344B3C564682DC393 /* Cache+ReuseInFlight.swift in Sources */,
-				CF9DDB2E269C971AE852D778A8CCB300 /* Cache+Salient.swift in Sources */,
-				D0CEB850FE25772437B1A1CBE9A767AD /* Cache+SkipWhile.swift in Sources */,
-				829E539A90ABE5D080FD17ECFF4AE662 /* Cache+Switch.swift in Sources */,
-				F920282F625DA5BB4CDA6E67CE519107 /* Cache.swift in Sources */,
-				34C6E92749ED85A4800601FE8DB66156 /* Caches.swift in Sources */,
-				476CE51CFE374CC103E02D5109D97D4B /* CompositeCache.swift in Sources */,
-				A4E2B29C80233AC31021A2309A0A9155 /* ConcurrentDictionary.swift in Sources */,
-				AD0FB6691F54959FCF08A42C63EFCC3A /* DiskCache.swift in Sources */,
-				9C3550115666116FA637AFB3F8D5E830 /* Droste-dummy.m in Sources */,
-				211152C91CAFAA59B1D967241EAC7027 /* Extensions.swift in Sources */,
-				98B40E0377F8DAFFF705741806CC0415 /* Fetcher.swift in Sources */,
-				8D6567C1F0DDBFF06DDE09D7550C46BE /* NetworkFetcher.swift in Sources */,
-				0C19AF878C5A3E578B8B887F4AFEDA7E /* Normalize.swift in Sources */,
-				F7398370A42FC5B84DC8C806DF9F880F /* NSKeyedUnarchiver+Swift.m in Sources */,
-				EC73F9394930FBFDDC833EDFFA6857A9 /* RamCache.swift in Sources */,
+				7A31FE8E8DA0619905B90B5C2AF5E792 /* AddRef.swift in Sources */,
+				29B90D6FCCB3F006EF87FBFA89E21988 /* Amb.swift in Sources */,
+				9C88B661FC1DF8271417A1C054F46C21 /* AnonymousDisposable.swift in Sources */,
+				27CB886DA24010A0EC45C21FD4A584CF /* AnonymousObserver.swift in Sources */,
+				294E6969BC1CF557346E9BD651F43F08 /* AnyObserver.swift in Sources */,
+				47AF15CFD9AAD74FB5AF01DD8536F920 /* AsMaybe.swift in Sources */,
+				4258AA593C9CCE33629ADBFA96526317 /* AsSingle.swift in Sources */,
+				A869B2D61FA859B7EAE37AD82830DF02 /* AsyncLock.swift in Sources */,
+				81A48621A5DF28A72AF3A47EBE1AA221 /* AsyncSubject.swift in Sources */,
+				25A5FF071D6A9C1712E9865086ED70B6 /* Bag+Rx.swift in Sources */,
+				EB0059B940120E9B5C542B5B90EFB042 /* Bag.swift in Sources */,
+				C7F89C4A0EBBE2EE0A2B5382EF62B2F3 /* BehaviorSubject.swift in Sources */,
+				EB706C8A7A10FD491AB6B163CF1D2A97 /* BinaryDisposable.swift in Sources */,
+				7C2EF58B912E7259CC6D697B1B6F43D3 /* BooleanDisposable.swift in Sources */,
+				512D468741ACC105E4F5B0683EA30FF9 /* Buffer.swift in Sources */,
+				3778B5D8CC22864E8BE2D23D1C215F60 /* Cancelable.swift in Sources */,
+				E1FA8607DAAF43BF240C8FBA9C560A8F /* Catch.swift in Sources */,
+				98904DAF6E34263431D58E2CC3692BF0 /* CombineLatest+arity.swift in Sources */,
+				CB541B3618202988A7918CD71B016111 /* CombineLatest+Collection.swift in Sources */,
+				920FDF9CDAFF2C29FDF5A20A2989DE7A /* CombineLatest.swift in Sources */,
+				FBBA1E4B4DBE81B4DCFDDE8E36061068 /* Completable+AndThen.swift in Sources */,
+				2788CC3E2DE956D85DDBABA95B85F732 /* Completable.swift in Sources */,
+				3767D1B81F29435BE1E897E3BE982563 /* CompositeDisposable.swift in Sources */,
+				E4BCC2EC3DAC29A3CE9CD05DC274F633 /* Concat.swift in Sources */,
+				2D662B9A68C43FBF41CF2F4623629EE7 /* ConcurrentDispatchQueueScheduler.swift in Sources */,
+				D735E672683E25B2458A468C0F7F5B39 /* ConcurrentMainScheduler.swift in Sources */,
+				13C199C1B90124DAF09DC5FB4866E02A /* ConnectableObservableType.swift in Sources */,
+				F474BADFE74D089BED1A044C43441AE4 /* Create.swift in Sources */,
+				986DB9A3D4F74012981EBA5A9DF83863 /* CurrentThreadScheduler.swift in Sources */,
+				B22125F12086DDF6F7C60A61DFD7AB54 /* Debounce.swift in Sources */,
+				6F80471CB473DFADBCA8E9CEBA903A74 /* Debug.swift in Sources */,
+				EA768A0C0F383FA71D7D2A486646F266 /* DefaultIfEmpty.swift in Sources */,
+				275723D3C6210BA56183816D9559C802 /* Deferred.swift in Sources */,
+				8F30978017E120C71371DFF352F93202 /* Delay.swift in Sources */,
+				D89F5FC51EFB96CE73F7740BAC34253F /* DelaySubscription.swift in Sources */,
+				5A4DB51C73E6A8EFDA81226D90B47E39 /* Dematerialize.swift in Sources */,
+				BB34681BD5746576B16270AD676815F2 /* Deprecated.swift in Sources */,
+				E724A866E04A8903CEBD7AA05FB9DD2E /* DispatchQueue+Extensions.swift in Sources */,
+				7C0CE098C1446EE13F0CB591462AD283 /* DispatchQueueConfiguration.swift in Sources */,
+				BB77F3591B3C495A781E5EB0EAAAC11E /* Disposable.swift in Sources */,
+				3B33D8F76BE5569B0CB062DE7640D4B8 /* Disposables.swift in Sources */,
+				60C4BC7DDC49CF4950D21DB6A5283FC5 /* DisposeBag.swift in Sources */,
+				DE7706A07C9E786D7CFB831E936D8FEA /* DisposeBase.swift in Sources */,
+				5728A34ABA8EFF53B7F9AF973D947880 /* DistinctUntilChanged.swift in Sources */,
+				627140526B26984EA9165F978D8C47E5 /* Do.swift in Sources */,
+				C8BF9C21FE17FDB7D765400C55C9F022 /* ElementAt.swift in Sources */,
+				0FA73ABD6671F5A64236EF3DE6FAAC85 /* Empty.swift in Sources */,
+				2CA018ECB6506E746F2EFBAD279B2100 /* Enumerated.swift in Sources */,
+				78D4C07385E6964BF397061623A952CB /* Error.swift in Sources */,
+				5A7D7153F2773BFCA1607F72E92B439A /* Errors.swift in Sources */,
+				A7CC61771761DD01B0ACC51BEC261700 /* Event.swift in Sources */,
+				DB74F2597C6240EFF3AE7DE3F9AD1CCB /* Filter.swift in Sources */,
+				88458AA9CC1F18DB80A3A465561626E2 /* First.swift in Sources */,
+				1769644B70D4B44752D87F64B7118673 /* Generate.swift in Sources */,
+				2F84D22F90A6E783B5B0528C02AAE4E8 /* GroupBy.swift in Sources */,
+				F34236CC526B8A4265F76F154ABF411D /* GroupedObservable.swift in Sources */,
+				93B9AD814CD5D31E681DDDF38BFF66F6 /* HistoricalScheduler.swift in Sources */,
+				4764374BC93274D75EA6FDDB269B4309 /* HistoricalSchedulerTimeConverter.swift in Sources */,
+				B69A88434BAD97CAB3E2054A950B8D72 /* ImmediateSchedulerType.swift in Sources */,
+				33139A81336AC126C8A40954143CA1B2 /* InfiniteSequence.swift in Sources */,
+				9D1FC1AF8CB4C716C9807CD6FD1F67D8 /* InvocableScheduledItem.swift in Sources */,
+				316749FD439F948A52326344A4198EB4 /* InvocableType.swift in Sources */,
+				88FD3A43286D9B35A1F884B0E3175F34 /* Just.swift in Sources */,
+				1A2C1F5126659B385FACC1F8C359962F /* Lock.swift in Sources */,
+				82311FFB6BC6EC9EEDFC0143EDE5BE1E /* LockOwnerType.swift in Sources */,
+				11659C99869BEA89EBBB3B8900843C1F /* MainScheduler.swift in Sources */,
+				27703FE37EE62F7CCCF99503C980AB87 /* Map.swift in Sources */,
+				277BA07071FDEEDC5D4C2620538F5B79 /* Materialize.swift in Sources */,
+				D2FE3CC7D9FCA5AA95833EF39E8E00A0 /* Maybe.swift in Sources */,
+				47C46114C297B26B7E6872051D095CF1 /* Merge.swift in Sources */,
+				7B5067845726AE1DAF8E288BB2F2E102 /* Multicast.swift in Sources */,
+				4769D5B34FFE8805959C1F0A694F1337 /* Never.swift in Sources */,
+				6B79B943AC0114647C37C5C8F190C5AC /* NopDisposable.swift in Sources */,
+				527A3DD5CF1560E5CBFB9D2AB223DB27 /* Observable.swift in Sources */,
+				691E8423DB01820E6983935709949B17 /* ObservableConvertibleType.swift in Sources */,
+				C5AD12068E297DC2244569981DBD75C1 /* ObservableType+Extensions.swift in Sources */,
+				1154CD7D9A18BA187BD62F9AC2E22A5B /* ObservableType+PrimitiveSequence.swift in Sources */,
+				6DB47D362BCBFFE24A4AB8CD0577020C /* ObservableType.swift in Sources */,
+				9F2376A521E351D92CEF44A0D5F01404 /* ObserveOn.swift in Sources */,
+				EC0A195F17EC6F5BE98231A71CB36943 /* ObserverBase.swift in Sources */,
+				8184767E4E316D41FED0C84EB249021B /* ObserverType.swift in Sources */,
+				03D7ABEEB3F5CAD02C5EF483A0C824AC /* OperationQueueScheduler.swift in Sources */,
+				74FD8FBE56488B3CBD5ECC531B847185 /* Optional.swift in Sources */,
+				DA8EB1D95471ABDE6CA6C3486EA99463 /* Platform.Darwin.swift in Sources */,
+				D030394158D6960DBD2C200F8CD06D27 /* Platform.Linux.swift in Sources */,
+				B813723B1CEBE911CB1ECA4A0B512CC3 /* PrimitiveSequence+Zip+arity.swift in Sources */,
+				A18F142FFCFD7DCF776DFF3CE0C644AD /* PrimitiveSequence.swift in Sources */,
+				71EB87EDD44013A62FCEBADB3347177D /* PriorityQueue.swift in Sources */,
+				737BF0731055BA94697516BFF81788D3 /* Producer.swift in Sources */,
+				A251B95396E8611BA18D8AE59C0A3981 /* PublishSubject.swift in Sources */,
+				9F92C1A2A795C5F648FDEDA434E95031 /* Queue.swift in Sources */,
+				C0331819D5BA3B306B51B338C0CF06CF /* Range.swift in Sources */,
+				159D66FF8F1B2C3D4EA217B4C19AD73D /* Reactive.swift in Sources */,
+				6456D893FD920D8901734FF59B7DA3E4 /* RecursiveLock.swift in Sources */,
+				868F38DA2EB129D7E31A10424210243D /* RecursiveScheduler.swift in Sources */,
+				59F05941C92B87CA2719D455E2A7CF85 /* Reduce.swift in Sources */,
+				5F7283D929DC6885D32F3BC2001A1D1F /* RefCountDisposable.swift in Sources */,
+				25052BA59B65807D88203BE1A14503C4 /* Repeat.swift in Sources */,
+				B9612A6A6744C5195724CC6ED08B72BC /* ReplaySubject.swift in Sources */,
+				39E920086BAA939E51EF706063032F74 /* RetryWhen.swift in Sources */,
+				5010E8CC1A303CF680DB04A7F6FD8599 /* Rx.swift in Sources */,
+				9D196D25057E03F88EF5D9E525DD96C1 /* RxMutableBox.swift in Sources */,
+				1F05D1A8B2EEBC878BEB45E7324C2251 /* RxSwift-dummy.m in Sources */,
+				435D113F94FB89E096EF59C9C43A5FA0 /* Sample.swift in Sources */,
+				0F52A5B16943C5852CECD827A344BD95 /* Scan.swift in Sources */,
+				554D0D04E88910C81E0DDAD3F6A55C5B /* ScheduledDisposable.swift in Sources */,
+				03188CDAFFD40BD101B4A8FB4D414B23 /* ScheduledItem.swift in Sources */,
+				431D97078DC63A8C62CB03F084A6E3DE /* ScheduledItemType.swift in Sources */,
+				05D3F1FD31EAAA792E3B1DC37661D923 /* SchedulerServices+Emulation.swift in Sources */,
+				22A35B5A639A852513DB1C741CFCA826 /* SchedulerType.swift in Sources */,
+				E2C03D3EE79FAEDCD3AFAABE0C61F1AA /* Sequence.swift in Sources */,
+				955F35606B9FB8A7D94FDB5DC4DC588B /* SerialDispatchQueueScheduler.swift in Sources */,
+				7B14DC948066CE6326C7E6A50ADBFAAA /* SerialDisposable.swift in Sources */,
+				FD10B27E735E32FA6B8002F8F9C5DEEE /* ShareReplayScope.swift in Sources */,
+				DA494E8BBDEF2913F85E33183BCE1BF1 /* Single.swift in Sources */,
+				45F683DAD98913377CB85EFF6EC4F914 /* SingleAssignmentDisposable.swift in Sources */,
+				FAF36F05C93A5AA8F8CDCC7835E5A484 /* SingleAsync.swift in Sources */,
+				2D937BB1FDCBE087EDB04584FC0D040C /* Sink.swift in Sources */,
+				321CB0B147B3E5A0D52B1F813265C99A /* Skip.swift in Sources */,
+				25EF3B3A5930CFFD54C90857C839673B /* SkipUntil.swift in Sources */,
+				41466042D0214DA5DE79F26B0FBA2982 /* SkipWhile.swift in Sources */,
+				1274B134CE9040B1449216A96010862D /* StartWith.swift in Sources */,
+				E0DCF434E4F151A17F4E3DA6BF6F34C3 /* String+Rx.swift in Sources */,
+				0173A4EEDD0605B7E9E47B073C11386E /* SubjectType.swift in Sources */,
+				8D54AD51F563D9CA5D26129F7207976F /* SubscribeOn.swift in Sources */,
+				8A9F8AE0722E8E48209E567BF842B8D5 /* SubscriptionDisposable.swift in Sources */,
+				061944FF69F1D7ED5E459B5E02F5EBB3 /* SwiftSupport.swift in Sources */,
+				25482E29D157C0980980474F2BAE0F18 /* Switch.swift in Sources */,
+				147D72F263555017EFF3DDE13471D15B /* SwitchIfEmpty.swift in Sources */,
+				618EEA8C9CBC83DFF17DFE6C683B991B /* SynchronizedDisposeType.swift in Sources */,
+				5F0B8E417E2CA48E2F3AA1091272D9FA /* SynchronizedOnType.swift in Sources */,
+				C78421AC4626B27875380626A5EC5F0B /* SynchronizedUnsubscribeType.swift in Sources */,
+				87EFC9EDB8A4ED842D65F3181E585F81 /* TailRecursiveSink.swift in Sources */,
+				25D1782C4EB5D0D78292908DC8341E43 /* Take.swift in Sources */,
+				3C5CE03ABE42D285736FEF12FC9A65E6 /* TakeLast.swift in Sources */,
+				E55ACC4131DB9B535FE3D6E56B3633EE /* TakeUntil.swift in Sources */,
+				D4B0746F12B5C2221EB678275BC076B4 /* TakeWhile.swift in Sources */,
+				BA26560D1ABFDB1CB344A7EF6A7595D4 /* Throttle.swift in Sources */,
+				ECE3DD34C51F1D409187936CF471B227 /* Timeout.swift in Sources */,
+				4338ACDD18BF99A590DD48619B1AAA42 /* Timer.swift in Sources */,
+				61B78DD247A6ACAF4F5ACD509789F13C /* ToArray.swift in Sources */,
+				84175B77120ADF5C9E3235F9BE0ABB9B /* Using.swift in Sources */,
+				9AE9B70764F86CD90EB32C1FF1D74BCC /* VirtualTimeConverterType.swift in Sources */,
+				136A3089581C6972224CBB3E322C33D5 /* VirtualTimeScheduler.swift in Sources */,
+				B20298FB9142E271D9840CB113897ECE /* Window.swift in Sources */,
+				D2CD3EEFFB8E600628F1884B7DCBC466 /* WithLatestFrom.swift in Sources */,
+				53BF9ADEE0A4CBFB006DE21BF9E7DDF3 /* Zip+arity.swift in Sources */,
+				59A0B9FF62BD7D3BF1EC9F41327BA7BC /* Zip+Collection.swift in Sources */,
+				380E1207677373B78A069BFB82D93BEF /* Zip.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		A33DE76A825484272493B561D8D6E68C /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2BF11EB9D40BD97A04E61193B8975554 /* Cache+Compose.swift in Sources */,
+				F38F0A4FBE7BFA39F834A31356D3C4DD /* Cache+Expire.swift in Sources */,
+				55BDC9F52B051264E39CFBAD34C54C26 /* Cache+ForwardRequest.swift in Sources */,
+				CAC5DE6DD742D9FD24FE7DFA1A748130 /* Cache+Map.swift in Sources */,
+				BA33B40D5D5F31B79D965ABFB8D3C923 /* Cache+ReuseInFlight.swift in Sources */,
+				09275FC7C7D330423761A5971735A452 /* Cache+Salient.swift in Sources */,
+				D87CB2C19CD44249826B5517B11B4D34 /* Cache+SkipWhile.swift in Sources */,
+				98376684833F9A5718A9371C8D57158A /* Cache+Switch.swift in Sources */,
+				4C8371EE4E418D8783350642CDDDBCF9 /* Cache.swift in Sources */,
+				A9E5824BC7FD57AEF46D9F26E0EA9444 /* Caches.swift in Sources */,
+				4C485FDA68C8C13A051687951DBBA7D2 /* CompositeCache.swift in Sources */,
+				73B6CB58A15C920155AA084FC2E222D1 /* ConcurrentDictionary.swift in Sources */,
+				CA4ECD10AE858BEF37CAFBE01E4D36C9 /* DiskCache.swift in Sources */,
+				7506657507E58162596B63B5B33DACFC /* Droste-dummy.m in Sources */,
+				DCD0BA81DAF12E219330DCA13D8F30AB /* Extensions.swift in Sources */,
+				61BC18D86FF21561A497ADC4D1865BCE /* Fetcher.swift in Sources */,
+				EFAE161FDCA95823BCA7AE8F2E75BF2A /* NetworkFetcher.swift in Sources */,
+				969FE1B9D6B5F6F983838C9A7AD2225D /* Normalize.swift in Sources */,
+				0194CB2DDD4E3A73B842A3DAE51A1614 /* NSKeyedUnarchiver+Swift.m in Sources */,
+				E0A7D6836C9A3242B4ED3B7D7EFE7D75 /* RamCache.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		0869ABA0765D7174E9605CDC7F5DDDBF /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RxSwift;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
+			targetProxy = E7FAB65AEDCB1EDEF0569E45A618BDA4 /* PBXContainerItemProxy */;
+		};
 		3E18BC209CACFE2830CD1BE609703C20 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Quick;
@@ -2032,25 +2042,25 @@
 		49DA055D0E097DBF05812ED3FDF83333 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RxSwift;
-			target = C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
 			targetProxy = 1699F41ADAEDAAB9AE67F6431482CD89 /* PBXContainerItemProxy */;
 		};
 		49E86D003ACE3A2C2B7058CA75A972AD /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RxSwift;
-			target = C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
 			targetProxy = 1199D1B5704D35AC623D1239C98E6403 /* PBXContainerItemProxy */;
 		};
 		5CE6306BDD69F1369136290311BAFDFF /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = RxSwift;
-			target = C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
 			targetProxy = C5A4A845EA0C8EE670D1099DF84094C2 /* PBXContainerItemProxy */;
 		};
 		773F8EE2C292C6BFDC805624D069A284 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Droste;
-			target = DD99D696E5267913E4B38DE2607FBAF8 /* Droste */;
+			target = 6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */;
 			targetProxy = A78C7A453F63DA606326A64B9E02C72E /* PBXContainerItemProxy */;
 		};
 		7F1F39AF5D7D4BFB59D71E95A9170D3D /* PBXTargetDependency */ = {
@@ -2062,14 +2072,8 @@
 		899C58F5B2405BA0F41AA30D470DAE80 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Droste;
-			target = DD99D696E5267913E4B38DE2607FBAF8 /* Droste */;
+			target = 6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */;
 			targetProxy = 4690A10ADB93BFF49EF15AF09554C1FE /* PBXContainerItemProxy */;
-		};
-		DD990774DE2663FAEFFB8CB0F8BD1BD1 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = RxSwift;
-			target = C8C978746B6442E1BF1F2F4A81B2D6E5 /* RxSwift */;
-			targetProxy = BD8433840EF50BF5D2E026E07BFAF5E7 /* PBXContainerItemProxy */;
 		};
 		FF3ECBA50DA84AFD3BD2709BC69621C1 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2146,9 +2150,9 @@
 			};
 			name = Release;
 		};
-		2D1E6A8838BC633DC4E447BEF6F9E766 /* Release */ = {
+		40DA04C3639C75E5CDC789AD2C51084D /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5549902C5D6DE95639A7A3406A2F6C1A /* Droste.xcconfig */;
+			baseConfigurationReference = EBE79703A5941E9D88946D36ABB3693F /* RxSwift.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2159,28 +2163,27 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Droste/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/RxSwift/RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Droste/Droste.modulemap";
-				PRODUCT_NAME = Droste;
+				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
+				PRODUCT_NAME = RxSwift;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
 				SWIFT_VERSION = 4.0;
 				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
 				VERSION_INFO_PREFIX = "";
 			};
-			name = Release;
+			name = Debug;
 		};
 		47C66D10ABAF9EBECB930B582FE20E89 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9D59156CA6CF8605BB1CFD83EBFF8F5 /* Droste.unit.xcconfig */;
+			baseConfigurationReference = 22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */;
 			buildSettings = {
 				CODE_SIGNING_REQUIRED = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -2232,37 +2235,6 @@
 			};
 			name = Debug;
 		};
-		4F2C7A1A569E89BD172C9251CAAC8642 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = EBE79703A5941E9D88946D36ABB3693F /* RxSwift.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/RxSwift/RxSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
-				PRODUCT_NAME = RxSwift;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 		4F540F672FED630C4D5E2CED3F0151DE /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */;
@@ -2297,7 +2269,7 @@
 		};
 		56F1BFFC0C9686138A434C0E317A0D3F /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = C9D59156CA6CF8605BB1CFD83EBFF8F5 /* Droste.unit.xcconfig */;
+			baseConfigurationReference = 22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */;
 			buildSettings = {
 				CODE_SIGNING_REQUIRED = YES;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
@@ -2312,6 +2284,38 @@
 				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				SWIFT_VERSION = 4.0;
 				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		577A74E56041993A1817F1C1E2C12C4B /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = EBE79703A5941E9D88946D36ABB3693F /* RxSwift.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RxSwift/RxSwift-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
+				PRODUCT_NAME = RxSwift;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
 		};
@@ -2471,6 +2475,37 @@
 			};
 			name = Debug;
 		};
+		9649365587591908AFE80360C08AE176 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Droste/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Droste/Droste.modulemap";
+				PRODUCT_NAME = Droste;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		98F29E7567052F62660DDD7069ADF73C /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -2526,9 +2561,9 @@
 			};
 			name = Release;
 		};
-		B1AE43464B2446193DF8C917B50C1C8A /* Release */ = {
+		DCA6064882EF4182211202F7559E7ED0 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = EBE79703A5941E9D88946D36ABB3693F /* RxSwift.xcconfig */;
+			baseConfigurationReference = C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2539,13 +2574,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/RxSwift/RxSwift-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RxSwift/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Droste/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/RxSwift/RxSwift.modulemap";
-				PRODUCT_NAME = RxSwift;
+				MODULEMAP_FILE = "Target Support Files/Droste/Droste.modulemap";
+				PRODUCT_NAME = Droste;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2590,37 +2625,6 @@
 			};
 			name = Release;
 		};
-		FE4BC90A48FA2687C42B10A9CD24A952 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 5549902C5D6DE95639A7A3406A2F6C1A /* Droste.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Droste/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Droste/Droste.modulemap";
-				PRODUCT_NAME = Droste;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
@@ -2629,6 +2633,15 @@
 			buildConfigurations = (
 				7C07ED8089F70A31B83996A8910D7F18 /* Debug */,
 				98F29E7567052F62660DDD7069ADF73C /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		316AD90DA728FE2E1EDD8B726E24DFD0 /* Build configuration list for PBXNativeTarget "Droste" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				9649365587591908AFE80360C08AE176 /* Debug */,
+				DCA6064882EF4182211202F7559E7ED0 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2651,29 +2664,20 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		803472A2C9FF67F95DEA8E708E6F0724 /* Build configuration list for PBXNativeTarget "Droste" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				FE4BC90A48FA2687C42B10A9CD24A952 /* Debug */,
-				2D1E6A8838BC633DC4E447BEF6F9E766 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		959C2E5C18F2254AEEA1EE838E626A8F /* Build configuration list for PBXNativeTarget "RxSwift" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				4F2C7A1A569E89BD172C9251CAAC8642 /* Debug */,
-				B1AE43464B2446193DF8C917B50C1C8A /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
 		9917E33A047ACB877A6604243E57D8E4 /* Build configuration list for PBXNativeTarget "Quick" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
 				58873EDE4149E38953869E2FFC3367CF /* Debug */,
 				F13E60F91EE9E33DA20F6024B0024EF0 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		BB1A0E3BE9000EBB8AC344A6C12965B0 /* Build configuration list for PBXNativeTarget "RxSwift" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				40DA04C3639C75E5CDC789AD2C51084D /* Debug */,
+				577A74E56041993A1817F1C1E2C12C4B /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Pods.xcodeproj/project.pbxproj
+++ b/Example/Pods/Pods.xcodeproj/project.pbxproj
@@ -7,341 +7,342 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		00266801C94BA359D35188E0D9E8A1F9 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE53107134BAB0E0AC7FBF2AA1BC6886 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0035E7B37533996D0B9ECB31FD85D03D /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FAD19357A80957099904472A89B7FA0D /* Nimble-dummy.m */; };
 		0173A4EEDD0605B7E9E47B073C11386E /* SubjectType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 73030AA83660A13E569AD0113EEB8D17 /* SubjectType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0194CB2DDD4E3A73B842A3DAE51A1614 /* NSKeyedUnarchiver+Swift.m in Sources */ = {isa = PBXBuildFile; fileRef = 8149C0BA1CCDF2D145E8FAA861C9F9F7 /* NSKeyedUnarchiver+Swift.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		02533B9F7F4CE9CD179E1F1E0E774F8A /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E71AEC51B010BB3D5AB352ACFBB17BE /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		03188CDAFFD40BD101B4A8FB4D414B23 /* ScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15A3F3BF839B9897E261ED3E39FE2649 /* ScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0338B975146864D901AA5E770DE5FD12 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE2CE670FF86727A412F5593CDD2A9E /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		037248D2F976E6C7AC3AC472274033CD /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C254261A9FC83104DF1D24C33F31110 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0327ADB8AE217772070D0E7334DD363E /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0549EB263233A4E143B87A2CB6B7DDED /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		034781968A6DA6AD8EDC118B7AFC6CB9 /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E496523B5977D63BD4BE1FC835F03A1D /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		03D7ABEEB3F5CAD02C5EF483A0C824AC /* OperationQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 814356EE1E9605CC4A9AC25448622168 /* OperationQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0433975FF172B8637364A40721435D62 /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E11AB03A3F11B7AFB7A0D0F19A0B3 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		04C241623428C470EC9A647F5CCAFF18 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		05ADC41A172933377F6606E2E513AC6E /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = AF17E0B9D2E8682E672520F4CCA1E0C4 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		05D3F1FD31EAAA792E3B1DC37661D923 /* SchedulerServices+Emulation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 647E651ED7B69A270E297A1E2E9976BC /* SchedulerServices+Emulation.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		061944FF69F1D7ED5E459B5E02F5EBB3 /* SwiftSupport.swift in Sources */ = {isa = PBXBuildFile; fileRef = D56DA18B320AAC1740C443786FDBB024 /* SwiftSupport.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0822659E8C3D41902B196E44C8AA9DC0 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605139D9F86CB74500BF0C1D13A2484B /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		08EDDF54E6AAF16AEA5D116786EB9D70 /* RxTest-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 810BCE23B1C947B337E42F6080A31924 /* RxTest-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		08EF70BB8DA11248DE6AB0D30C443BCA /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F760993273BAFD1F853A8923273368A /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		07104AAD5CBFCC2D4E0621332C63AF92 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D050E7B4E77C5F8F398043AE2B42DD /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		09275FC7C7D330423761A5971735A452 /* Cache+Salient.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE78517930A474EF59907D69BBFFC104 /* Cache+Salient.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		095331F60096F4DCE71960DFFD33935A /* Droste.h in Headers */ = {isa = PBXBuildFile; fileRef = 7FE02D88F98AE2E31C5E483D3AD5E674 /* Droste.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		0CAD7AAF511C7091B684129E05F8E390 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4916EB8BE4199D7627C169F2CA6B91 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		0D223A33663A0C7B8E9389D375AD8613 /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AE8D9AB2CF3C93E0C153DEDA2F0AD11 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		0BCF52716C57DC50BF353DE57A7B9538 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429A78EFD4693FA32211655BDAE214CA /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0EFB98E8D2124B6CA9701C6EED622D31 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
 		0F52A5B16943C5852CECD827A344BD95 /* Scan.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1C0F9554E85E94DB66EDF8F5964EDC0C /* Scan.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		0F8ED804E38975CF7427076D67F25148 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB84063868E7FF0FEEACB89F09651C18 /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		0FA73ABD6671F5A64236EF3DE6FAAC85 /* Empty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28754340AEF03EB84EA98ADFDCF1EE5F /* Empty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		10F5D42D18FA365F6D5C3D201485CF16 /* Behavior.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0549EB263233A4E143B87A2CB6B7DDED /* Behavior.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		100040029E359770EB8AC8F8D9D28B7D /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = BD4550F0446F62D284F47CECFFB7CF7C /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		100523DCE660DF847B7C1AF80F9D3D13 /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 446AA99E502C856B575FA5D1DCAC47B5 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		1154CD7D9A18BA187BD62F9AC2E22A5B /* ObservableType+PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 108EFBCF28406ECBB643D5EC949493CF /* ObservableType+PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		11659C99869BEA89EBBB3B8900843C1F /* MainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A1FD49CBC095971BF93E61BB94883D /* MainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		11CAC00690EF608FFD244013E7C4849B /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
 		1274B134CE9040B1449216A96010862D /* StartWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 70C2CDFAEC61EFDD038EE89B7310CBAD /* StartWith.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		136A3089581C6972224CBB3E322C33D5 /* VirtualTimeScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7EEBC6B47328C37B6BC71434FF08C52B /* VirtualTimeScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		13C199C1B90124DAF09DC5FB4866E02A /* ConnectableObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 83EE71F0FE105E79407BC049D2A38772 /* ConnectableObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		147D72F263555017EFF3DDE13471D15B /* SwitchIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0424E1790219422B7EB6B251ED7429B0 /* SwitchIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		155D1F1399F0B4991583B041BEF0C9CA /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5405B04137B75CB6DFCD07879C98E13F /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		159D66FF8F1B2C3D4EA217B4C19AD73D /* Reactive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 95332C62694E7BDC87A33226B19B43C5 /* Reactive.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		15B10C41A64E1F8A43A6D2826A55EF37 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCAF829B1C8D3DA675E0C02B226EF70 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		1687FAE4E4C13F98300A1598C8E2F021 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78833EBBC71D330C71218DBAAA1A4B9 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		1769644B70D4B44752D87F64B7118673 /* Generate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B9A6A90586B5D6FF6007D3A8CAE078A /* Generate.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		17D7DE0B2CCB42E91FA9F5A814627E4E /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 185AF272F0B6DA8C8F9441D231093075 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		187EC0620251090769818DB7E19C0051 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E16CB41EEE80933DC59102A1CF876EA /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		1A2C1F5126659B385FACC1F8C359962F /* Lock.swift in Sources */ = {isa = PBXBuildFile; fileRef = DD067F7995E2B5EBCF8D7991F6C0001D /* Lock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1A5484C69EE89B6F67B8B8CDE2031D83 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA31BF7406BCC195F45681092F5E2A /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1BD39EE039F926A0B74547141BF598A7 /* RamCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2ACB9B1E7C386D1C65F90BD7539B766 /* RamCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1C709EE10D8D243ECABF876EA1E08E77 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B0C116AA997C58F9C6A65868A1329 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1E6A3CAAD29C874F988D4FF14C18D5C2 /* Nimble.h in Headers */ = {isa = PBXBuildFile; fileRef = 185AF272F0B6DA8C8F9441D231093075 /* Nimble.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1F05D1A8B2EEBC878BEB45E7324C2251 /* RxSwift-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 3D60A169920697B20C2D24FB59E5AD6E /* RxSwift-dummy.m */; };
-		1F66D9DC2277C1493303E986C77D2152 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9761F27F54E78828A2B807DAB2A25879 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		213FC97651D608E8761A2FB58479ADC3 /* RetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		1F19FAB2B06C8A7BABE0201C6C2126E8 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F466C67722461ED16EEB149A87B6B44 /* AsyncMatcherWrapper.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		22A35B5A639A852513DB1C741CFCA826 /* SchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A0F4EE119E65A2790A5BEE531ED8E21 /* SchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		23C7AA4804BAE5923E216C317F3C6774 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64299BE07801777F3AD2B98E369C01A5 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		24E0E6E24A1712F5379A2E76B6CE1F88 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AEBCEC65280E1F273BF5299035E47 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		22BEBE8D12A13ABDA7961E91631DB89B /* ForwardRequestOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1DA66BD11DFE1B44AEE8B3E87FE69247 /* ForwardRequestOperatorTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		22DF4863E0D7977723ED68FE95215B13 /* Event+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790D1254BDA12208B89C11C83294C733 /* Event+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		25052BA59B65807D88203BE1A14503C4 /* Repeat.swift in Sources */ = {isa = PBXBuildFile; fileRef = A58E0F0B1A3B6F28663FC08EB3ACDE78 /* Repeat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		25482E29D157C0980980474F2BAE0F18 /* Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C65B7F488687567D2AD4AEB111AAB8BA /* Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		25A5FF071D6A9C1712E9865086ED70B6 /* Bag+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3EB2550B5110CA4FB9C6FD26836A6EBC /* Bag+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		25D1782C4EB5D0D78292908DC8341E43 /* Take.swift in Sources */ = {isa = PBXBuildFile; fileRef = CE18E0BFD2918C0E3F1B5AB26CA5D95F /* Take.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		25EF3B3A5930CFFD54C90857C839673B /* SkipUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B6842D0BDC309FDCB3C54B56A18F7BB /* SkipUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		267C95483B8179811B8A0DD88D5BEDD9 /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 935B7F52803202DC339031D5E9057028 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2675B73BE9B31F6C3E983EA107D9BC7A /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555905450B901A902E8F94CD656E4D97 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		275723D3C6210BA56183816D9559C802 /* Deferred.swift in Sources */ = {isa = PBXBuildFile; fileRef = B9677E9E790094792357AB00A80B5F99 /* Deferred.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		27703FE37EE62F7CCCF99503C980AB87 /* Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F239EF1F6D92241D56ABA8E4C73B440 /* Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		277BA07071FDEEDC5D4C2620538F5B79 /* Materialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 88AE06D808F2F25DAA9F9ACDF64372B7 /* Materialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2788CC3E2DE956D85DDBABA95B85F732 /* Completable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0825C5C72FF462971F73D71DB1F4B853 /* Completable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		27CB886DA24010A0EC45C21FD4A584CF /* AnonymousObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = A01B9AC2AE3E5160F770D7E24A360B21 /* AnonymousObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		286B5E36914A9F2061957A13237F73C0 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E886E1FED4D952D5788F7C4696FA1F /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		294E6969BC1CF557346E9BD651F43F08 /* AnyObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = B808B09CF83EB3F57ABF9F7E375B8057 /* AnyObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		29B90D6FCCB3F006EF87FBFA89E21988 /* Amb.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B4F446ADE478C1C1E01A6DF2EAD0BEE /* Amb.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2B581E08B43374A783FE338A9CFC96BE /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDE67C898D6218C71BCA27B4970A5A1 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2A58E9A888BDB7D89E8B6616A38E49BE /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AECE5F1CFACBB7D053E7C0D000BD3A2 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2B5ED02193CF6426178C33403A3B758F /* SuiteHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1F760993273BAFD1F853A8923273368A /* SuiteHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2BF11EB9D40BD97A04E61193B8975554 /* Cache+Compose.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20E8BD9801D9F2445DF683A261C21ABA /* Cache+Compose.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2C8F0DBC6229BEFB4288C1E2ACF9C082 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF68BE3CB6608B515CE233AD8231A2 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2C1920FE333EF913B24327D034C9302C /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6D2B2E9F09759467884361D3E27E69 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2C3654FB63E633F8A5C79A9DE55781C2 /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE885E75504F9F1BF14039E44FB01500 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2CA018ECB6506E746F2EFBAD279B2100 /* Enumerated.swift in Sources */ = {isa = PBXBuildFile; fileRef = 075EB582A63C32140E7D9741CF677CA4 /* Enumerated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2D662B9A68C43FBF41CF2F4623629EE7 /* ConcurrentDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = C162ADAA8658A02659DCAC1E8364D596 /* ConcurrentDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2D6EA5E18070C714792BE43026DD1EE7 /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7DD93F264BC535D061EC8536AE9D8B /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2D937BB1FDCBE087EDB04584FC0D040C /* Sink.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF14725542D87B58BC2E9CEFE8368AA5 /* Sink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		2DD307F1CD8D3C1143C764EF397C641A /* HotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E953C4F03F79DF6469B6ABFF6AF88345 /* HotObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2E302D4719721C7ACAEE1C0FF92F288D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
+		2F0C096D44EB16CFC5C096180E141680 /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801686A5B36A736D3641815EE1D4204 /* RxTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		2F84D22F90A6E783B5B0528C02AAE4E8 /* GroupBy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D993FEFA0466F8C553B6AAF5A4F255F /* GroupBy.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		2F8B8E3412F1417ED63AE6537D309EA8 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = FDCAF829B1C8D3DA675E0C02B226EF70 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		30E158B927813D8E19ECF751BBD3A200 /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EAE65D1A37CBBBF2C4FA465BAFD079 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		316749FD439F948A52326344A4198EB4 /* InvocableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0881E653DB56735064FFE28E4C372564 /* InvocableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		321CB0B147B3E5A0D52B1F813265C99A /* Skip.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2F6B103DE3F9F97F83E6C476C1B16C5 /* Skip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3235D9456CB5346F22E9D7903078656C /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
 		33139A81336AC126C8A40954143CA1B2 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9EC43508F7BCF0D0844BC4CB3969BE63 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		332F326CC09BFB2893BB6F8BB34F6A8E /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABE976D29E82D47711F15A1E106E8B /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		34D7852543CAA5550D357F3942F490AC /* TestableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B62E0023CFA5E49361FBA265A510BF3 /* TestableObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		34FF11A9E918D299FC5C448C132C8881 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DF150BFE695968F04236FFF189878F /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		34C700F822FC761AD16BC133743C68DA /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8F7F09C9A6A330BD5F368C8609657 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		34E8D8FAC5D3AADC86C85354C1315E7E /* ExpireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6433A35C5237951780F71007CDD7CAF6 /* ExpireTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		354033E6429C35730A350582C22A65AB /* Pods-Example-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 699118D7DDD5F335E4FB8B17DC0F12D2 /* Pods-Example-dummy.m */; };
-		35E3FA5431060710A7FECBE30D97763D /* CurrentTestCaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 427A864D7DB8FDF816621B3A36D25152 /* CurrentTestCaseTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
-		364515488BACFF39184BA19D0D51715A /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		36A2373F2EB063A0FFE26862A7DF2367 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EA88F354299C8AB82E10AED0726677 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		374DBC00BF9FEDD8B49906A0B58047F4 /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 09ED5D24C2B42766C425AE76FACDD05C /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		3767D1B81F29435BE1E897E3BE982563 /* CompositeDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8328E7C0D6403714ECE7338CC9440073 /* CompositeDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3778B5D8CC22864E8BE2D23D1C215F60 /* Cancelable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC2626B8358940692B134A160E14C32 /* Cancelable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		37B9F41B358AAFFC676590924B0E191B /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A35FBA742FC0639CB1C60CA73765C85 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		380E1207677373B78A069BFB82D93BEF /* Zip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 90117FABAAFBA5499FEFE1ADD97272AC /* Zip.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		39E920086BAA939E51EF706063032F74 /* RetryWhen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14688EEE13E18098791B2E48FF192795 /* RetryWhen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3A83142C8B4E0192E195304A5CEB9D17 /* SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 350347333DA3AAD73E912D8327670F65 /* SwitchTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3B33D8F76BE5569B0CB062DE7640D4B8 /* Disposables.swift in Sources */ = {isa = PBXBuildFile; fileRef = EE726664E88FA4A800280396E6EBE7CA /* Disposables.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		3C5CE03ABE42D285736FEF12FC9A65E6 /* TakeLast.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8FA7D068830C8E38B73913ABA551D6AA /* TakeLast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3E5F7F47A7092E1944CF1CD29EFD51F5 /* SalientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		3F131EB45A58205368E66823F52EC878 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EEAFCA4A8E32343B7D61B76A6405D /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		3FCB2579409B473B309D3E2FAE7FC839 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		40169289DF2BC00F8B82EA06790181A8 /* SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0D968CBD8F99AB066F734268201544D7 /* SkipWhileTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		403E5A276EBCADBC9617B535B1C2B17F /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB15D4B650BF63162F7CD9FF7E2558F9 /* DiskCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		407FFF7FB7CA8918878DBF85E500161F /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A3D868BDEAE5EE7CBF2F39D26B8C2B /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		408C27536AEAF9E424152DEB52A87BC5 /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F5167D86BA16961527E0E405A7149A36 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		41466042D0214DA5DE79F26B0FBA2982 /* SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE29623F1E75DD8832C602FF1FA3FF98 /* SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		417119A72C1A2864BCA69C711F6B550B /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DAE05351EC6B959EBA64BAF862395F /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		41C0706128DFD0BB660A262FBFE86401 /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E1FCBDFE3DD9AF98DAA6B0274E8048 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4258AA593C9CCE33629ADBFA96526317 /* AsSingle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C2F7551F3ABE331C18F6C0D2BF5001F /* AsSingle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		42A447EDEA9D4513DC3C329D3635F305 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F869E070B98513E85F2F7921AEAC /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		431D97078DC63A8C62CB03F084A6E3DE /* ScheduledItemType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 71FF73BA6D2BE9A0DD6E2B7FB04382EF /* ScheduledItemType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4338ACDD18BF99A590DD48619B1AAA42 /* Timer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3CDF9BFF6F914D4F8E12C8E5F85922F9 /* Timer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		435D113F94FB89E096EF59C9C43A5FA0 /* Sample.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3517B45D9C3D29D33E054064596EC37D /* Sample.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4597E5BF849E6709638CCCCA28D51F4E /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AA58C96DBD798CAE5DFC169065D36EB /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		45A507E8E58BC6414049A9267578D9FB /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F4C9B8DEFAA1296AC1C58825EA5FBA /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		45F683DAD98913377CB85EFF6EC4F914 /* SingleAssignmentDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C20112E2D057B83282A63E76E8FA565D /* SingleAssignmentDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		461D85757088B19B697B15FDBC06A648 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
+		4726DC318DFF420715F28B907136D3F5 /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD1E8FEC73AF4E7DCE459A7D16BAF2 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4764374BC93274D75EA6FDDB269B4309 /* HistoricalSchedulerTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 456AA1151E2EB02F7FE37EBBFE64EBA0 /* HistoricalSchedulerTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4769D5B34FFE8805959C1F0A694F1337 /* Never.swift in Sources */ = {isa = PBXBuildFile; fileRef = 654A93D8653FA5EF9411A69B18AB621F /* Never.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		47827C14E719AE98A4BFA54B51504F05 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1CE888EF874F9D96852F9371F34FEA /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		47AF15CFD9AAD74FB5AF01DD8536F920 /* AsMaybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F96F3E7E0E183E02B71545016D7559 /* AsMaybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		47C46114C297B26B7E6872051D095CF1 /* Merge.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6F4CCF58DC99E09361656CDEB3F969AB /* Merge.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4A0774063C4895027EDC5542CF7995EE /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
+		49ED66912320BA9BC54420B42D175D9A /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F07E2AD84356249665F58A1256D281 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4C485FDA68C8C13A051687951DBBA7D2 /* CompositeCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0CCEEF36C09885B713A3D7560E100904 /* CompositeCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4C5BB237628BDD6B0FB3143E58CB0FF4 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28089142BAB02F317AD1CA3C743F4161 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		4C8371EE4E418D8783350642CDDDBCF9 /* Cache.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E67A0D7B7413977E91583D48768D24B /* Cache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4D472FBA13EE73EB46A7740DEC941A60 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8670ADBA31F83F75BA94F9ABA974F3 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		4D80D9E6AFD7C9745D7FD55AEE345317 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8565A00AAA29127E3A316E9921DBE732 /* RxTest.framework */; };
-		4E43B22EB39D579A360E8AB2EB54EC1F /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EDA30233CDB9F471E3F31C8B71EB /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4D646CBF416302DB9A2A6A2509BBED66 /* ContainElementSatisfying.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA4AEBCEC65280E1F273BF5299035E47 /* ContainElementSatisfying.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		4FC1416F7D01F0A436D1227F8F9255D0 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC17FB90E566827515A71578B2BBA3 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5010E8CC1A303CF680DB04A7F6FD8599 /* Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1CBB5EB74E0D9C84930C7438F7640E03 /* Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5023D249C03A75C6E8B18800A0DDDE0C /* Expectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A9E11AB03A3F11B7AFB7A0D0F19A0B3 /* Expectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		501A98E45401392A376203775FC884A0 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F97F9E0F5FA166C24534977251F38 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		512D468741ACC105E4F5B0683EA30FF9 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8808EAB77FFB53FD5AE82864839F82 /* Buffer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		515C61278B15FA564587EF581B9B8655 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 48DAE05351EC6B959EBA64BAF862395F /* DSL.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		51B119C5686545183621B7B51516BB3A /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374A0DAFD6D8FF7495CEBC805719A79A /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		51C649D1B46B04259DFCB5A40FA23008 /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8A6753BE6CC5702F03A94774613D01 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5190B51F924F8AD52E26E8DE90313375 /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EA39E9E71A1FC29AA92E535D177682F /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		527A3DD5CF1560E5CBFB9D2AB223DB27 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E5C4436206C8A0E350BABC0165A4DFEE /* Observable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		53892A7B91F7D479A1533E8774CB60A9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		53BF9ADEE0A4CBFB006DE21BF9E7DDF3 /* Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD223D6831D0AC58EDFA33069A37F497 /* Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		554D0D04E88910C81E0DDAD3F6A55C5B /* ScheduledDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0E96538CB79CC8AF348E3364422431F4 /* ScheduledDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		55BDC9F52B051264E39CFBAD34C54C26 /* Cache+ForwardRequest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 15ADFD4E713416D860EAA5D3AB70052D /* Cache+ForwardRequest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		55ED80AC201E95BA04B5DC8CF05F537B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
+		56AB742771942AE81290855FB0996174 /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F099B690CEC2A42B92999FF085FBD9EC /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5728A34ABA8EFF53B7F9AF973D947880 /* DistinctUntilChanged.swift in Sources */ = {isa = PBXBuildFile; fileRef = F546642C51F69052520612EAA9986664 /* DistinctUntilChanged.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		57A9D441866697C17FBAF6137D9F03FC /* QuickSpecBase.m in Sources */ = {isa = PBXBuildFile; fileRef = F5167D86BA16961527E0E405A7149A36 /* QuickSpecBase.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		59A0B9FF62BD7D3BF1EC9F41327BA7BC /* Zip+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9AA1890ABEC35BB449F3F5683C6B2425 /* Zip+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		59F05941C92B87CA2719D455E2A7CF85 /* Reduce.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8771C43A89854E33143BC1E490E982F /* Reduce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5A1B09C912B9630C872E2D30900ED305 /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5ECA959FB88D251D51EB6430C7D29D /* TestScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5A4DB51C73E6A8EFDA81226D90B47E39 /* Dematerialize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 624AE40A0FCA86E1F3E1D79669BAF589 /* Dematerialize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5A7D7153F2773BFCA1607F72E92B439A /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = B8FF8CF506C383DA0B139B097FCBADB1 /* Errors.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5C663E6DB2E98D355C1BB362174AF99C /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E699A9C8240E18A9ABDF1DCEE7DD1985 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5CF8106293869D3A64AAF22EE090B035 /* AdapterProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 27E886E1FED4D952D5788F7C4696FA1F /* AdapterProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5E33EEB7ABFA2760656B87D8B6E72819 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DEF6971B000CB7E6C2A7079CD93E15 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5C66BF3A9B35D2257EF745DFE37BF209 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738135910E0064CB147B94B21A757452 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5E19B9FEF3A1078504C437EC6258C3B2 /* Any+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A6EF2A5694A31A5CDF6AF7E7B00AC8 /* Any+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		5EEAB8DED758DC68CE147666CAEFBAAA /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36512327D1A7F96D0F72E260C392CB4 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5F0B8E417E2CA48E2F3AA1091272D9FA /* SynchronizedOnType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 08F88EB886E9B11A3ACE686A7DE97749 /* SynchronizedOnType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		5F7283D929DC6885D32F3BC2001A1D1F /* RefCountDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 31F93BC7E647D0D2021806296CF59E89 /* RefCountDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		5FE08B18FBF244AA9BB56F0CB350CFCC /* ForwardRequestOperatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		602229A466EA9CC6CF6EBB292FA92817 /* Any+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8A6EF2A5694A31A5CDF6AF7E7B00AC8 /* Any+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6003555E09F7F27869B172832826CE35 /* Stringers.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39D1EDA30233CDB9F471E3F31C8B71EB /* Stringers.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		60C4BC7DDC49CF4950D21DB6A5283FC5 /* DisposeBag.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D0D12CD7CA4FA31C47EA57756F53C78 /* DisposeBag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		613A85087648D76248BDDC254B4EC8D6 /* RxSwift-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 586FC161DF179CF64CFFD5DBA3E8AA7F /* RxSwift-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6157E82919CAAB844BE2E31AE397A0BA /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AFD76D04B1BF859FA77E7363C393977 /* Nimble.framework */; };
+		6180C47F2B0EB475803F1534F1421DCA /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BD64FCED7B504354A3E304CB75C022 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		618EEA8C9CBC83DFF17DFE6C683B991B /* SynchronizedDisposeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0EE2787BAD6CAB49C44AC814A83A2ED6 /* SynchronizedDisposeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		61B78DD247A6ACAF4F5ACD509789F13C /* ToArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = E50638A0FFF40CE3653E500FAB7819CF /* ToArray.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		61BA2BD935A823290AB8F7A856AAD5F1 /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75861FD8178EE58B01ECD63DD21C67D /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		61BC18D86FF21561A497ADC4D1865BCE /* Fetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3A0EB6A4389D465A59BCD1881AC9266A /* Fetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		627140526B26984EA9165F978D8C47E5 /* Do.swift in Sources */ = {isa = PBXBuildFile; fileRef = 889F73266A196B3FE3BB0537221C3009 /* Do.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		62BD2DC0DE27B3CC5547033587D7F4E2 /* DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 429A78EFD4693FA32211655BDAE214CA /* DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6329C05469EDF9F7AF31A51F04DF1680 /* NimbleEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7F07E2AD84356249665F58A1256D281 /* NimbleEnvironment.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		62FA8B8420F4213B31E5A1C4688F0EFA /* Droste.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7212959077D3C9F5654377DDE47A6E15 /* Droste.framework */; };
 		6456D893FD920D8901734FF59B7DA3E4 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED041943DDAED283CAEC5877017A31D3 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		665C69BF167AB9818CAC3DDC938C0AD9 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		670B083E1504146B3E2A30272B18D861 /* CwlDarwinDefinitions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 64299BE07801777F3AD2B98E369C01A5 /* CwlDarwinDefinitions.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		68B167D6C1B22455F2EAA972D832377A /* URL+FileName.swift in Sources */ = {isa = PBXBuildFile; fileRef = F75861FD8178EE58B01ECD63DD21C67D /* URL+FileName.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		691E8423DB01820E6983935709949B17 /* ObservableConvertibleType.swift in Sources */ = {isa = PBXBuildFile; fileRef = CF9FA296A61F02C71E067B65E060AF9A /* ObservableConvertibleType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6938331AF11B34267092E3295B450621 /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178C07C7BE7B5B19970CE0A778488E18 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		69DACF7910975210BA9897B4E0080974 /* MapTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6EEABCAB89B88547BEBA17DF0A3C9CC5 /* MapTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6B72424DAB576D1A36F3D377E1588C07 /* AssertionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 374A0DAFD6D8FF7495CEBC805719A79A /* AssertionDispatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6B79B943AC0114647C37C5C8F190C5AC /* NopDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = CDFACB25ABE7EF55F68113515C4ED284 /* NopDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6C3C2F7CE2F2D9E88AE09D5FCFA5A0B9 /* CacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6B89CFAFD61D9C3C9976C0BA383A8A97 /* XCTest+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		6D8B10BB6D916241AEC69BE37058258F /* TestSchedulerVirtualTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713A3DCE03735AC480D0E3DE0BC5EE1 /* TestSchedulerVirtualTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6DB47D362BCBFFE24A4AB8CD0577020C /* ObservableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = A5DF324C6A2B21E73811CBF46C7D33FA /* ObservableType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6F2AECB6C7DFFE5CBE8183B0AE0FFB28 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BA43064F9A852B1B6860BCE449DFB169 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		6EBB9405C47705B0A44AD6ABCC426982 /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC071859004A73F33D532D5F42FF61D /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		6F80471CB473DFADBCA8E9CEBA903A74 /* Debug.swift in Sources */ = {isa = PBXBuildFile; fileRef = AF9AF554228C539C0AD66F41BFA9CC1C /* Debug.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		6FACBE27BD32B91E914476ECBEF3BC9C /* Nimble-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 8EA39E9E71A1FC29AA92E535D177682F /* Nimble-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		715DE0702F64C0CE5D086F93BF303CED /* ExampleGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = D6E1FCBDFE3DD9AF98DAA6B0274E8048 /* ExampleGroup.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		71B0F56FCA8DDD413B15FA01D9EFC251 /* ErrorUtility.swift in Sources */ = {isa = PBXBuildFile; fileRef = FE53107134BAB0E0AC7FBF2AA1BC6886 /* ErrorUtility.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7028F2E784641F4B5DF87FD5EFD78932 /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CB075012E5CF90FC620CE801F83F7E12 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		7084172FE15A62B02531E50AC74BD89B /* HotObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = E953C4F03F79DF6469B6ABFF6AF88345 /* HotObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		708E65BFBDA565CBDE17704F6F3F10F9 /* ExampleMetadata.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A35FBA742FC0639CB1C60CA73765C85 /* ExampleMetadata.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		715ABC8247032BC59858306F0863F757 /* BeCloseTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D4916EB8BE4199D7627C169F2CA6B91 /* BeCloseTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		71EB87EDD44013A62FCEBADB3347177D /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4208096FBE5A3697F4691455C57A52A9 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7233C02A9E2357048270B76C12F53CB2 /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = D618449AFC6917EC84F2472DDF576D19 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		722F71331605250E7B859AD9ADB7D509 /* EndWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = C2AF68BE3CB6608B515CE233AD8231A2 /* EndWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		72EB92E7B93CADA1070FEA0B86F493B8 /* CacheFake.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFC198862F343DAE257E3514E8D69763 /* CacheFake.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		737BF0731055BA94697516BFF81788D3 /* Producer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 561ECF42DDB43FE546FAB01764F01B68 /* Producer.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		73A328FCE4AE1F06C999EB46025609F9 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		73B6CB58A15C920155AA084FC2E222D1 /* ConcurrentDictionary.swift in Sources */ = {isa = PBXBuildFile; fileRef = F93367B5FFE412E86E6141363502F1B4 /* ConcurrentDictionary.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7472792FC36E7A0BBDDD4941632FBDA2 /* Quick-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = BA43064F9A852B1B6860BCE449DFB169 /* Quick-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		74FD8FBE56488B3CBD5ECC531B847185 /* Optional.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5CDEDF71C13611D83ACF75918250AB50 /* Optional.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7506657507E58162596B63B5B33DACFC /* Droste-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = 4DBA052779C5A889D0080E10D183D0E0 /* Droste-dummy.m */; };
+		75659A8E5A24F634C04DF77945CD4589 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFC985C0C75E35B4A6AE383A847DCC5 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		78D4C07385E6964BF397061623A952CB /* Error.swift in Sources */ = {isa = PBXBuildFile; fileRef = 65C1CFBF23986F7F678D8874DF9471E6 /* Error.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7A31FE8E8DA0619905B90B5C2AF5E792 /* AddRef.swift in Sources */ = {isa = PBXBuildFile; fileRef = E03A8B108B52F54A50E12C0F9ABB0C2F /* AddRef.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7A9902FD148183A1987F0264C57F36EF /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763782B58373E3F28DE2DCD725868E02 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7B14DC948066CE6326C7E6A50ADBFAAA /* SerialDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAFFC3B84174FAEC2D251A30EF3A7B52 /* SerialDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7B5067845726AE1DAF8E288BB2F2E102 /* Multicast.swift in Sources */ = {isa = PBXBuildFile; fileRef = D42CFB6F18F1DB156575243FE21B434B /* Multicast.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7C0CE098C1446EE13F0CB591462AD283 /* DispatchQueueConfiguration.swift in Sources */ = {isa = PBXBuildFile; fileRef = 897A823B4CBE909FE21497D7A966D313 /* DispatchQueueConfiguration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		7C2EF58B912E7259CC6D697B1B6F43D3 /* BooleanDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CE0E2A8918AFEAB4B5E7E462139244A /* BooleanDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7D3235B869EC4E03C93667C9C163DEB1 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = B702C9652B23C8F94B293211DD96F3C7 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7D71695D29F3E73697770D4EEAFCDFE8 /* ColdObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E5D67BF2841C2B6B8A7805B2BFB84 /* ColdObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7DC290E3B2877F32EC1B0AC16D16A4C7 /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 834ED52643B582A82D56536389F11FA6 /* World+DSL.h */; settings = {ATTRIBUTES = (Project, ); }; };
-		7E394284D01F55E407892097E309C943 /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA059ADFF8022A8F87B7D63FB4614C8 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7E8B959FC0E11ADE51DE16EE46D40F16 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		7F7B286BF3C99EF4CB2711E8971CD24F /* RxTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0801686A5B36A736D3641815EE1D4204 /* RxTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		7FEEB9A55BB971E787C4F5253979EE61 /* Event+Equatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790D1254BDA12208B89C11C83294C733 /* Event+Equatable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7C4A6B872D68CBF09646F0ED641C7FE3 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = C0D2F869E070B98513E85F2F7921AEAC /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		7F7CD3F520043289B2466AE08F56BF1E /* RxTest-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A73C789D855DEF04139E173F02CE64 /* RxTest-dummy.m */; };
+		7FCC470102CC8131FED8CDB7EEE2D050 /* Async.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605139D9F86CB74500BF0C1D13A2484B /* Async.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8184767E4E316D41FED0C84EB249021B /* ObserverType.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1D1B3DDDC079647155BC0893F747601 /* ObserverType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		81A48621A5DF28A72AF3A47EBE1AA221 /* AsyncSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8BF1B97667C167D9815FDD505BF522 /* AsyncSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		82311FFB6BC6EC9EEDFC0143EDE5BE1E /* LockOwnerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C855E1F240198863501B0AD4F112A227 /* LockOwnerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		83262CD39AE9A9BD559A810326CFC2B0 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F89F28CB63883E9DDDECBE8DA2928F /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		83508471FA7071F046963012E421E604 /* XCTestObservationCenter+Register.m in Sources */ = {isa = PBXBuildFile; fileRef = 3AA58C96DBD798CAE5DFC169065D36EB /* XCTestObservationCenter+Register.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		84175B77120ADF5C9E3235F9BE0ABB9B /* Using.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98BFBAE0B2D0F4EDF8D893E80BFB1AE0 /* Using.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		85255B609E18C5FEC187E4F957DED344 /* TestSchedulerVirtualTimeConverter.swift in Sources */ = {isa = PBXBuildFile; fileRef = A713A3DCE03735AC480D0E3DE0BC5EE1 /* TestSchedulerVirtualTimeConverter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		85D264B5009002B7A79971C8413C870E /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C22A1615527B150C21741AF1D991D24 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8419A6E5B0BFFA00D90502674F2C9D52 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1D4526BCB1D674C22D81B95CBB4612 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		84D4D494211E8CE4734CF497E97E9E50 /* RecursiveLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = A78833EBBC71D330C71218DBAAA1A4B9 /* RecursiveLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		868F38DA2EB129D7E31A10424210243D /* RecursiveScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9B5BEDED3CD0D8DDE85A2D11207DD18A /* RecursiveScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		87EFC9EDB8A4ED842D65F3181E585F81 /* TailRecursiveSink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4512FFE04700ECE71D158BF5B6F3A4DC /* TailRecursiveSink.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		88458AA9CC1F18DB80A3A465561626E2 /* First.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7BA10C614BE6C945F2AF6EFD8CD6FDF /* First.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		88FD3A43286D9B35A1F884B0E3175F34 /* Just.swift in Sources */ = {isa = PBXBuildFile; fileRef = AC23D858B2A515A23808022D5F2DD7D7 /* Just.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8A9F8AE0722E8E48209E567BF842B8D5 /* SubscriptionDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 390947F0F397720A36AA2256A8B80572 /* SubscriptionDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8AA53B8407F6A08C6E4C99BD764EB1AD /* RetainTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4847C65728065B2E0B3B10E56917CA2F /* RetainTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		8CC0E034F66B6DF3C809ED90A9627A6E /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C47A86BF8ACB0C8A501B53C54125E6 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8D54AD51F563D9CA5D26129F7207976F /* SubscribeOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 528B2C0000D84EC325E9E80E284B37A9 /* SubscribeOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		8F30978017E120C71371DFF352F93202 /* Delay.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8ADDAFE8A1473712231745EE23863851 /* Delay.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		920E53F0080CFED03D09DA32387F0F3C /* Errors.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3AECE5F1CFACBB7D053E7C0D000BD3A2 /* Errors.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		90D2D84A537BC0D61BA74660FD617572 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B102093BA04370529D8C3EFE29F80 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		920FDF9CDAFF2C29FDF5A20A2989DE7A /* CombineLatest.swift in Sources */ = {isa = PBXBuildFile; fileRef = 11271157EE354CE9358AE9774380C0BC /* CombineLatest.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		923A2A207D32196A384A162E6A39C7C0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1F9E5187F3C5AA1B098A820C8121AF /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		92EFBA0D7A20A381C3F4CDB81F098883 /* CwlCatchException.m in Sources */ = {isa = PBXBuildFile; fileRef = 905B102093BA04370529D8C3EFE29F80 /* CwlCatchException.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		92F6EBE1E3056184EBF35ECC37C332F0 /* ThrowAssertion.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2A1F9E5187F3C5AA1B098A820C8121AF /* ThrowAssertion.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		93B9AD814CD5D31E681DDDF38BFF66F6 /* HistoricalScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = E3C452554BDE351A5CEB8E24DCFB934D /* HistoricalScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		955F35606B9FB8A7D94FDB5DC4DC588B /* SerialDispatchQueueScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3389D1AE2E13C76B4B14E029DCC420A /* SerialDispatchQueueScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		95A8A8F25D6CF1A35AB7C4F342EEDBC5 /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D42A9F7F0C4E92C7D8065D70B4DD6AFE /* Quick-dummy.m */; };
+		9601A8CE0C80EBC0ABABFA39194EFE0A /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F89C69F00F905174B0FFBEBF16B23AC /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		965F8142A4F0472484E1E5C8BE034447 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C036E198D7FA1F251CE2C2D623B8EC20 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		966CC50694AC798D8DFAE8AC4138571B /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		969FE1B9D6B5F6F983838C9A7AD2225D /* Normalize.swift in Sources */ = {isa = PBXBuildFile; fileRef = 234C79C3E2DF0647B7127BD9B736D60D /* Normalize.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		98376684833F9A5718A9371C8D57158A /* Cache+Switch.swift in Sources */ = {isa = PBXBuildFile; fileRef = D87C44A47BD0F817D12FDE011002A153 /* Cache+Switch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		985712939F4C71581F37E82F0942DB5B /* SatisfyAnyOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = D618449AFC6917EC84F2472DDF576D19 /* SatisfyAnyOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		986DB9A3D4F74012981EBA5A9DF83863 /* CurrentThreadScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57E47B5D388A4DD83CAB93471D121A92 /* CurrentThreadScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		98904DAF6E34263431D58E2CC3692BF0 /* CombineLatest+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = 452698D4DE0E21EA0996260EABB3D6AE /* CombineLatest+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9A8FEF430D75035EA575F460AEC15D11 /* XCTest+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		98A5B83D0FCB4A3D85BCEBF0A86EE615 /* World+DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 834ED52643B582A82D56536389F11FA6 /* World+DSL.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		9A471840E1C9822AEC8B16286E648901 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DF399EDFBE684FB01A9134183BDC79 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9AE9B70764F86CD90EB32C1FF1D74BCC /* VirtualTimeConverterType.swift in Sources */ = {isa = PBXBuildFile; fileRef = C656FB4C600D0B66A0CA26EA3CA1C6B6 /* VirtualTimeConverterType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9B43BA0E11406E19169A84DE6F1531C4 /* mach_excServer.c in Sources */ = {isa = PBXBuildFile; fileRef = 5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9B82931CAF7DC34D81B207DF2A30E160 /* CwlCatchException.h in Headers */ = {isa = PBXBuildFile; fileRef = 99A3D868BDEAE5EE7CBF2F39D26B8C2B /* CwlCatchException.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		9B956F87081C78FE2142CB966A82C286 /* Nimble.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6AFD76D04B1BF859FA77E7363C393977 /* Nimble.framework */; };
+		9B56FFEF00CEEECEE9CFB893913D3B97 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = BD4A59E727AA546B89DF4132569CD49F /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9B9E9F382B2E314BBA1AA468E656A113 /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C666618A086B6BC13A87EEEC55D5051 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9C88B661FC1DF8271417A1C054F46C21 /* AnonymousDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = A780A534B38DE71C0A2986E58F56EF23 /* AnonymousDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		9CEC63C8A312477703953FA38D4DCF46 /* World+DSL.swift in Sources */ = {isa = PBXBuildFile; fileRef = 786B0C116AA997C58F9C6A65868A1329 /* World+DSL.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9C89191AC13AEBBD62B15334E626AC65 /* QuickSelectedTestSuiteBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1D8670ADBA31F83F75BA94F9ABA974F3 /* QuickSelectedTestSuiteBuilder.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9D196D25057E03F88EF5D9E525DD96C1 /* RxMutableBox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FFD8DA031C932F6A1387C77E541154CC /* RxMutableBox.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9D1FC1AF8CB4C716C9807CD6FD1F67D8 /* InvocableScheduledItem.swift in Sources */ = {isa = PBXBuildFile; fileRef = FEAC9F628163F0D65E621153714528FB /* InvocableScheduledItem.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9D5F46678C5A4F7A92F6A656D49A1375 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 74E4F5A94A6C5AB2493BE2DA0F47F7A2 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		9F2376A521E351D92CEF44A0D5F01404 /* ObserveOn.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4D4AD59559CE5395612189B0ABF91761 /* ObserveOn.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9F808FF20A668602DEAFB7580B752FAD /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06464B3E1258E03B1C46A2DD64028A76 /* Subscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		9F92C1A2A795C5F648FDEDA434E95031 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F54A3B30611A47020ECCDA28872E892 /* Queue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A18D1604A0B3A836C1EE6530A3440EFB /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DC5812F31B21591951EFBAF40445FFB4 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		9FB15E160ECB83E7F1628ED882BDC001 /* NMBExceptionCapture.m in Sources */ = {isa = PBXBuildFile; fileRef = 76EA88F354299C8AB82E10AED0726677 /* NMBExceptionCapture.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A00DF3D28294DC105D232BDFB555BD1C /* NMBObjCMatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF8A6753BE6CC5702F03A94774613D01 /* NMBObjCMatcher.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A188195A19BA5B428E1428A5A57A0D70 /* ExampleHooks.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9761F27F54E78828A2B807DAB2A25879 /* ExampleHooks.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A18F142FFCFD7DCF776DFF3CE0C644AD /* PrimitiveSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 599A56FB0BD0A419A50451DADC8E2D60 /* PrimitiveSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A19D89D3683E4368230D52014DC2D77A /* NMBStringify.h in Headers */ = {isa = PBXBuildFile; fileRef = CB075012E5CF90FC620CE801F83F7E12 /* NMBStringify.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		A251B95396E8611BA18D8AE59C0A3981 /* PublishSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2D02803FF50E3F48FF54BE828EDC2A50 /* PublishSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A336C23F7C23DC23DF6FDD5F0CECFCC3 /* Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF6D2B2E9F09759467884361D3E27E69 /* Functional.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A4BC6C72C51E19148125E207BE9A8369 /* ToSucceed.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7AFC985C0C75E35B4A6AE383A847DCC5 /* ToSucceed.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A4EC249AB8725E04B8C310D785BFE993 /* TestableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97A167AE3E61565ABFF1430236CD2CE /* TestableObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A620F798081291E0BF981FACCA5C701A /* NSString+C99ExtendedIdentifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7DD93F264BC535D061EC8536AE9D8B /* NSString+C99ExtendedIdentifier.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A635C44A2419A9684A22993B4052CAD6 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55533DD388D650E3B3D03F21B5992570 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A79E72FE105B16E7C6A6FBC79D7D0E7D /* Configuration.swift in Sources */ = {isa = PBXBuildFile; fileRef = E496523B5977D63BD4BE1FC835F03A1D /* Configuration.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A4719B47039DAA3C1834E3C842757861 /* RxTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8565A00AAA29127E3A316E9921DBE732 /* RxTest.framework */; };
+		A6965EEDB02B6D5CC2AAF36B401E48D4 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B139738E8AB1BCB198F68731ED0053 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A7CC61771761DD01B0ACC51BEC261700 /* Event.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A7D715D5363605B3D84F701394CA127 /* Event.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A869B2D61FA859B7EAE37AD82830DF02 /* AsyncLock.swift in Sources */ = {isa = PBXBuildFile; fileRef = D8B189A16C05A14C69624B1D23DEAB3C /* AsyncLock.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		A917918EFE191842B5EE36EF3394AD74 /* World.swift in Sources */ = {isa = PBXBuildFile; fileRef = E36512327D1A7F96D0F72E260C392CB4 /* World.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		A8C2D601AD691613F2EF1DC66DAF9468 /* BeLessThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = D3F4C9B8DEFAA1296AC1C58825EA5FBA /* BeLessThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		A9E5824BC7FD57AEF46D9F26E0EA9444 /* Caches.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3FC750EC952E121097BF47124F783F5E /* Caches.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ADB92CFC629B21F098BAEC90D415555E /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E48E4CFF3E795C7F7FC6C05461A260 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		ADBE46FFD944AE1D82BA9B45427182EF /* SkipWhileTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B00EFAD11F1688A53D238E159B927B0B /* Predicate.swift in Sources */ = {isa = PBXBuildFile; fileRef = DDC071859004A73F33D532D5F42FF61D /* Predicate.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B0C72020BCE863374F0BC3DB4309A924 /* DSL.m in Sources */ = {isa = PBXBuildFile; fileRef = BD4A59E727AA546B89DF4132569CD49F /* DSL.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B1EBF61F0F3922F1A7BE4223E9D53703 /* DSL+Wait.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B1D4526BCB1D674C22D81B95CBB4612 /* DSL+Wait.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B1F1F5352BEC3C86A4FAE68ADD6CBBB9 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E59896EDF05625CF489C9362A4C628 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B20298FB9142E271D9840CB113897ECE /* Window.swift in Sources */ = {isa = PBXBuildFile; fileRef = D220738394C885CAE465F0CC85974514 /* Window.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		B22125F12086DDF6F7C60A61DFD7AB54 /* Debounce.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0FF8963A749934021EE631E46FA8D10 /* Debounce.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B367074DB2213FAA1691102597FF7EC6 /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B453A74BA45777678EA48C8167C550C5 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
-		B4BAF015C8BFE16A986A3EC50C6C015E /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE9A9B5D9C6D7155ED2F3AF4A912C26 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B53CB156734BA4AF716A555B86835701 /* Contain.swift in Sources */ = {isa = PBXBuildFile; fileRef = 763782B58373E3F28DE2DCD725868E02 /* Contain.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B554A2742210AD6F85A6A0736D76093B /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 555905450B901A902E8F94CD656E4D97 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B5B2E421BCB6D195CE3F2C03DC8E4FB9 /* NMBExceptionCapture.h in Headers */ = {isa = PBXBuildFile; fileRef = 6F89C69F00F905174B0FFBEBF16B23AC /* NMBExceptionCapture.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B69A88434BAD97CAB3E2054A950B8D72 /* ImmediateSchedulerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = BB6F135951F0F23BEDF8068C9C66C27D /* ImmediateSchedulerType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B6B8C4D3AC2DECB5235003BAFE605603 /* AsyncMatcherWrapper.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F466C67722461ED16EEB149A87B6B44 /* AsyncMatcherWrapper.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B80B26512BDC6877614B7261B16C27A9 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB84063868E7FF0FEEACB89F09651C18 /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B6B8C5DF02CDEBEED5B6CF226F9C1ADA /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 664E444158D22087931A52AE7C54FFC7 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B813723B1CEBE911CB1ECA4A0B512CC3 /* PrimitiveSequence+Zip+arity.swift in Sources */ = {isa = PBXBuildFile; fileRef = B36C37D0620E19DE982B14EE97CB492D /* PrimitiveSequence+Zip+arity.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		B8399AE8B9E042325C5811DE04010F8C /* DSL.h in Headers */ = {isa = PBXBuildFile; fileRef = 4AE8D9AB2CF3C93E0C153DEDA2F0AD11 /* DSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B9612A6A6744C5195724CC6ED08B72BC /* ReplaySubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E91B5759B010D20E06F6FDC133675F5 /* ReplaySubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		B9E4929B50A4BAD5701FB9542002525E /* RamCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BA1FAC97337A997DDBDE9AEF2AEA7A75 /* NimbleXCTestHandler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E16CB41EEE80933DC59102A1CF876EA /* NimbleXCTestHandler.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BA26560D1ABFDB1CB344A7EF6A7595D4 /* Throttle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C823EEE007452668D8D018D5A5EC0 /* Throttle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BA33B40D5D5F31B79D965ABFB8D3C923 /* Cache+ReuseInFlight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5C57A36289AA8F980AA9BDB67D172505 /* Cache+ReuseInFlight.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BA39B670C01B024FA6756E32A48280BE /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */; };
-		BB2CFA70A57B42F5EA411A9F26A1DEA8 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB5546987339D3006C11834A93DA985 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BB34681BD5746576B16270AD676815F2 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = A680D9DEB2C7328F188018204948F159 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		BB77F3591B3C495A781E5EB0EAAAC11E /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C616271A38C3EEDFCB5D35828D794B2F /* Disposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BBBECC463322F65D4D03D6295D1BC5CE /* BeginWith.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6C666618A086B6BC13A87EEEC55D5051 /* BeginWith.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		BC990A5DC96C7060B48BC1E95B04443F /* MatcherProtocols.swift in Sources */ = {isa = PBXBuildFile; fileRef = 79BD64FCED7B504354A3E304CB75C022 /* MatcherProtocols.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		BB99054FD78CF548A1A39EA67BBC5ECD /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
 		BE2A47CB3A4EAABCEFBDFFE3AFCDDBAA /* Pods-Example-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = C9BDE82371C83FA9AE91B05F77ACAA36 /* Pods-Example-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		BFE8C09D04E45686008F06A90985941F /* CompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C8527356AC567E100A57C036BD72B60D /* CompositionTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C0331819D5BA3B306B51B338C0CF06CF /* Range.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0D122B4BB2E236A54975BD2A0227F3A /* Range.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C09336ACB4D11C3629F19E1B4681281B /* HooksPhase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DE885E75504F9F1BF14039E44FB01500 /* HooksPhase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C12F0FB7402DE4A2770978C5BB4C6850 /* CompositionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C1E82F9FF2CD436979970279B888205A /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF943B822AE7953A9003EE518D903DEA /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C2887A332D9BD897477B72B0238D65D2 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */ = {isa = PBXBuildFile; fileRef = 9A1F97F9E0F5FA166C24534977251F38 /* XCTestSuite+QuickTestSuiteBuilder.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C357FB2E6BC6670AA2AF6DE89F5888F4 /* RxSwift.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = F72EBA400A5BD9F325FFBE55A059694B /* RxSwift.framework */; };
-		C527FF40212046670FD1641E63B0CD29 /* BeGreaterThanOrEqualTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4DF399EDFBE684FB01A9134183BDC79 /* BeGreaterThanOrEqualTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C0FB155C937E91344D74B564681F59AA /* Quick.h in Headers */ = {isa = PBXBuildFile; fileRef = AF17E0B9D2E8682E672520F4CCA1E0C4 /* Quick.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		C5A66BF9668B90C4769CE8F2D37DBA60 /* QuickTestSuite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 080EEAFCA4A8E32343B7D61B76A6405D /* QuickTestSuite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C5AD12068E297DC2244569981DBD75C1 /* ObservableType+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9BAA4E81E2A603ABE6B8DE1F922F5240 /* ObservableType+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C6EE3EBFB01CBC1D9906A7A7E4FBEED1 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
+		C72069155B3EF931B30201994DD05EE1 /* Match.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6FDE67C898D6218C71BCA27B4970A5A1 /* Match.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C78421AC4626B27875380626A5EC5F0B /* SynchronizedUnsubscribeType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34E8F0725F629126DB6F582017176D9C /* SynchronizedUnsubscribeType.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C7E98561C51ADBC90C794A41B3D7D9DC /* ExpectationMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8AA059ADFF8022A8F87B7D63FB4614C8 /* ExpectationMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		C7F89C4A0EBBE2EE0A2B5382EF62B2F3 /* BehaviorSubject.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC3DD92AFC2E510C7B449FED87EDCE01 /* BehaviorSubject.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		C8A09A059FF9EAF51DEC9ADE2BCA6250 /* Subscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06464B3E1258E03B1C46A2DD64028A76 /* Subscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C8705CA3C98E596170FDE29F5E8502E6 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DCDEB24981E3CB732C4381FA626D10 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C899F3FE4F590583DA7830E9877A349F /* QuickConfiguration.h in Headers */ = {isa = PBXBuildFile; fileRef = 09ED5D24C2B42766C425AE76FACDD05C /* QuickConfiguration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		C8BF9C21FE17FDB7D765400C55C9F022 /* ElementAt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52BCCE1CBFDAB8CE24C44B3C3FECFA4E /* ElementAt.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		C927F2E0DDDE5F68D980E282A76BF60B /* HaveCount.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFE9A9B5D9C6D7155ED2F3AF4A912C26 /* HaveCount.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CA4ECD10AE858BEF37CAFBE01E4D36C9 /* DiskCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE2EDD7BD06778C4A66DD3B695604617 /* DiskCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CA882FE5A3E6F480BD18DD67D966F3C1 /* Nimble-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = FAD19357A80957099904472A89B7FA0D /* Nimble-dummy.m */; };
 		CAC5DE6DD742D9FD24FE7DFA1A748130 /* Cache+Map.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF7887A82F93E99219E90E8C6BBA5125 /* Cache+Map.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CAED3B4F1864F2283C0B956968F84089 /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24D050E7B4E77C5F8F398043AE2B42DD /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CAD86463B4A70A207144C5118F655808 /* BeLogical.swift in Sources */ = {isa = PBXBuildFile; fileRef = B702C9652B23C8F94B293211DD96F3C7 /* BeLogical.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		CB541B3618202988A7918CD71B016111 /* CombineLatest+Collection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61F77F4B181B08425951C1175E1C5714 /* CombineLatest+Collection.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CBABD90934812B50C2F261D11EE2566A /* RxTest-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = 810BCE23B1C947B337E42F6080A31924 /* RxTest-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		CC1263FF41D9835F846B465CCBA7C49F /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
-		CC12FFD5BAD0834C3974E340673BD861 /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E18A7FF7CBDA9450CB94DEC9DC7F70 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CC8E9462D1FAEECEA04E0716A18B1A50 /* Callsite.swift in Sources */ = {isa = PBXBuildFile; fileRef = 05B139738E8AB1BCB198F68731ED0053 /* Callsite.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CE2484C9FC0C3BBA40DEA9E2CA5ED960 /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEF59E38EE96A73E582FC4F0B2CCDE8 /* Recorded.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CF14CEE4CE4FB9E86123214E940DE63A /* RaisesException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 61EAE65D1A37CBBBF2C4FA465BAFD079 /* RaisesException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		CFA899A6977D2252AE6B33761B0EE0B7 /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF67B416E1A9557AC0D4822F59DD545 /* World.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		CD1C082E29EE239F066589D552C24F28 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4353C7E8B48EF2A0828594A6E1AEB458 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CEC1A867FA11B37AE0A7E45FAD04AA43 /* BeAKindOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DEF6971B000CB7E6C2A7079CD93E15 /* BeAKindOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		CF69A10E7589A79739C42311743426FB /* TestableObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = F97A167AE3E61565ABFF1430236CD2CE /* TestableObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D030394158D6960DBD2C200F8CD06D27 /* Platform.Linux.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0A4250907D10CED5894873CB05B98773 /* Platform.Linux.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D0349514048A756AD550ED37322ED591 /* Droste.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 7212959077D3C9F5654377DDE47A6E15 /* Droste.framework */; };
-		D0676BDA3BCB33B0C778AC93180963A5 /* QuickSpec.h in Headers */ = {isa = PBXBuildFile; fileRef = 664E444158D22087931A52AE7C54FFC7 /* QuickSpec.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		D1E2FA965DB95066E3ECC9F2D90B2773 /* SwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D2CD3EEFFB8E600628F1884B7DCBC466 /* WithLatestFrom.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3C64788EFA087B5960001B6155C636A8 /* WithLatestFrom.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D2FE3CC7D9FCA5AA95833EF39E8E00A0 /* Maybe.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59FDB452C5DFA7C19F6658D53AF9F8A3 /* Maybe.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D3CFC809A9CBE1EF88F4F3337C4B775D /* RxTest-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = A2A73C789D855DEF04139E173F02CE64 /* RxTest-dummy.m */; };
-		D48BF578ECC0043772B4E83CF8D27DB7 /* NMBExpectation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4353C7E8B48EF2A0828594A6E1AEB458 /* NMBExpectation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D4B0746F12B5C2221EB678275BC076B4 /* TakeWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8CAE7C2A80A89C089E3A118C05B6E405 /* TakeWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D58A2C27F18C5386AC39A340968E0C0B /* DiskCacheTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		D5CC02225146A5DEF9E2B6DB3CA8941E /* ReuseInFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D5250A5EC4E62D98C98F39BE3879A459 /* Recorded.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECEF59E38EE96A73E582FC4F0B2CCDE8 /* Recorded.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		D5C20373469F194ACFAB5785A1AF231C /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4614C36300843A53B2E48EB7750C0F /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D735E672683E25B2458A468C0F7F5B39 /* ConcurrentMainScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2B3ACC3A810F1D86386DC66DD864706 /* ConcurrentMainScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D87CB2C19CD44249826B5517B11B4D34 /* Cache+SkipWhile.swift in Sources */ = {isa = PBXBuildFile; fileRef = 02725AA6B05AACA955021B485CF40E0D /* Cache+SkipWhile.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		D89F5FC51EFB96CE73F7740BAC34253F /* DelaySubscription.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA885A063120E9224890A1BDF6C0E8B9 /* DelaySubscription.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DA1E4B7C3F3DB30397DF51DF436637E2 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E96B4FCF763CCF5848F3A04BDEE3C /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DA494E8BBDEF2913F85E33183BCE1BF1 /* Single.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7181441ED03EE29184C112B38209E46 /* Single.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DA4F9EB339859168966BD00BC30981E0 /* Deprecated.swift in Sources */ = {isa = PBXBuildFile; fileRef = C036E198D7FA1F251CE2C2D623B8EC20 /* Deprecated.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DA8EB1D95471ABDE6CA6C3486EA99463 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = E02932E0F16695277F04D1B0CA7FA2C2 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DAE19DAC20BD3B93A30F5F4BDF61D622 /* AssertionRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = BF1E96B4FCF763CCF5848F3A04BDEE3C /* AssertionRecorder.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DB74F2597C6240EFF3AE7DE3F9AD1CCB /* Filter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0F5F9FA62D15DA8072B6714CEFFDC103 /* Filter.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DBA334B9C35E5354E5E81B790C836BC6 /* QCKDSL.h in Headers */ = {isa = PBXBuildFile; fileRef = BD4550F0446F62D284F47CECFFB7CF7C /* QCKDSL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		DBE50B01C01F2D3FAB82D54F1839D3BE /* TestScheduler.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B5ECA959FB88D251D51EB6430C7D29D /* TestScheduler.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DCD0BA81DAF12E219330DCA13D8F30AB /* Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DCE66E389058625109957CB220D66ED6 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 144AA2A04F9B8638D587586EC4E32F4A /* Quick.framework */; };
+		DE179C2759B9844D71CEB963606F36F4 /* QuickConfiguration.m in Sources */ = {isa = PBXBuildFile; fileRef = DC5812F31B21591951EFBAF40445FFB4 /* QuickConfiguration.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		DE7706A07C9E786D7CFB831E936D8FEA /* DisposeBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3F1884DFC444445AE3DAE8479FA02472 /* DisposeBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		DEE0EB0FDD41001482465830F89E6A9D /* Equal.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBCD1E8FEC73AF4E7DCE459A7D16BAF2 /* Equal.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DF6EF09153BD06DEF7B5961BE7EEE973 /* Platform.Darwin.swift in Sources */ = {isa = PBXBuildFile; fileRef = 55533DD388D650E3B3D03F21B5992570 /* Platform.Darwin.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		DF791F01AC3B0727A9D1FC3B8232B637 /* CwlCatchException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 67F89F28CB63883E9DDDECBE8DA2928F /* CwlCatchException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E098C31348AB780FEE7DDEC5651DDC2C /* BeVoid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E699A9C8240E18A9ABDF1DCEE7DD1985 /* BeVoid.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E0A7D6836C9A3242B4ED3B7D7EFE7D75 /* RamCache.swift in Sources */ = {isa = PBXBuildFile; fileRef = A9609E7445AACEDC561F4A22C96B9ACB /* RamCache.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E0BC3784027574E48764B59D168EA9B9 /* MatcherFunc.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4CA31BF7406BCC195F45681092F5E2A /* MatcherFunc.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E0DCF434E4F151A17F4E3DA6BF6F34C3 /* String+Rx.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E74A6E007520ECCE695064780621BC4 /* String+Rx.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E1C46E6FAF7BF8D4501F8424293DD834 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2318D795FE872771B8CB9D1BEAD0E1EB /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E1FA8607DAAF43BF240C8FBA9C560A8F /* Catch.swift in Sources */ = {isa = PBXBuildFile; fileRef = C7FD76819C1FCE81806064C89E577597 /* Catch.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E244EE6DD1CD7B6B24871510C1A33735 /* BeIdenticalTo.swift in Sources */ = {isa = PBXBuildFile; fileRef = DACC17FB90E566827515A71578B2BBA3 /* BeIdenticalTo.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E2B9515C01F752D52C0C73E004E6A0F0 /* CwlMachBadInstructionHandler.h in Headers */ = {isa = PBXBuildFile; fileRef = 74E4F5A94A6C5AB2493BE2DA0F47F7A2 /* CwlMachBadInstructionHandler.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		E20731EF3C9E63E600A6543FF010798C /* PostNotification.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5E71AEC51B010BB3D5AB352ACFBB17BE /* PostNotification.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E22691B24ADA0C2D815BDC01DD363468 /* World.h in Headers */ = {isa = PBXBuildFile; fileRef = EDF67B416E1A9557AC0D4822F59DD545 /* World.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		E24DFF99625B4F55D281C66A0C0A98F8 /* CwlPreconditionTesting.h in Headers */ = {isa = PBXBuildFile; fileRef = DBE2CE670FF86727A412F5593CDD2A9E /* CwlPreconditionTesting.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		E2C03D3EE79FAEDCD3AFAABE0C61F1AA /* Sequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = B6A853DBF6D21EC875FD8AD8B1F1EE71 /* Sequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E4BCC2EC3DAC29A3CE9CD05DC274F633 /* Concat.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4A90C41F1F0F546F4FE02F94B36DEDBC /* Concat.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E4C9E089C63F6E75F3285F937AABBD3A /* CwlMachBadInstructionHandler.m in Sources */ = {isa = PBXBuildFile; fileRef = 71E48E4CFF3E795C7F7FC6C05461A260 /* CwlMachBadInstructionHandler.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E55ACC4131DB9B535FE3D6E56B3633EE /* TakeUntil.swift in Sources */ = {isa = PBXBuildFile; fileRef = D4838D06F6A58651D1B6B19228C82B07 /* TakeUntil.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E720CC01C8CA5C0DDB57078682328DAC /* BeNil.swift in Sources */ = {isa = PBXBuildFile; fileRef = F099B690CEC2A42B92999FF085FBD9EC /* BeNil.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E632A03015466359CB70AAE352527805 /* BeAnInstanceOf.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9DF150BFE695968F04236FFF189878F /* BeAnInstanceOf.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E681DCE69FACEB7060056E09BDA8F3FD /* TestableObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8B62E0023CFA5E49361FBA265A510BF3 /* TestableObserver.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		E724A866E04A8903CEBD7AA05FB9DD2E /* DispatchQueue+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = F8590B74B6F82B567F528AF587959257 /* DispatchQueue+Extensions.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		E7F0FF8B1D94AB9A664B0DCED67B1189 /* mach_excServer.h in Headers */ = {isa = PBXBuildFile; fileRef = 5405B04137B75CB6DFCD07879C98E13F /* mach_excServer.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		E965A95077F792A9FC7460640BBFEBE4 /* BeGreaterThan.swift in Sources */ = {isa = PBXBuildFile; fileRef = FC4614C36300843A53B2E48EB7750C0F /* BeGreaterThan.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		E97A6C3D69EA07CF23194E38920F88AA /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		EA768A0C0F383FA71D7D2A486646F266 /* DefaultIfEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = B319C2062C21BF38BC241BE0C439F296 /* DefaultIfEmpty.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EB0059B940120E9B5C542B5B90EFB042 /* Bag.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFCDCCD2CB84A44273B4917DA700515E /* Bag.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EB393AE3D576DA534054C79DE95735B8 /* AllPass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 21A8F7F09C9A6A330BD5F368C8609657 /* AllPass.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EB706C8A7A10FD491AB6B163CF1D2A97 /* BinaryDisposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = C9535482AAB6042AA7B9F4708C95A8F1 /* BinaryDisposable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EB8ECAEB27B4A2EC19B3BB18EA6AD193 /* BeEmpty.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2318D795FE872771B8CB9D1BEAD0E1EB /* BeEmpty.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EC0A195F17EC6F5BE98231A71CB36943 /* ObserverBase.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBDAA2E09549A7E0FCBF9EBDD3D88519 /* ObserverBase.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		ECE3DD34C51F1D409187936CF471B227 /* Timeout.swift in Sources */ = {isa = PBXBuildFile; fileRef = 537A211511A8B2175890320C5F6414D8 /* Timeout.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		EF78F2E60D13696826206C4079ED238E /* Quick-dummy.m in Sources */ = {isa = PBXBuildFile; fileRef = D42A9F7F0C4E92C7D8065D70B4DD6AFE /* Quick-dummy.m */; };
+		EE43FF4CECE1001483748FE3FF80D410 /* CwlBadInstructionException.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6DB5546987339D3006C11834A93DA985 /* CwlBadInstructionException.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		EFAE161FDCA95823BCA7AE8F2E75BF2A /* NetworkFetcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD21BA2BB3EB0AEFF28486AF4D2144D3 /* NetworkFetcher.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F02213CBB1768C8EFB1FFAFCB606C163 /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B1B3A690A4215A45B8E138937F690C /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		F0A67405FE63AF28FCED2F0297D07164 /* Expression.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF943B822AE7953A9003EE518D903DEA /* Expression.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F0AE3DA6E950970BCE1C5DEDF3551A01 /* NSKeyedUnarchiver+Swift.h in Headers */ = {isa = PBXBuildFile; fileRef = D9B4773C9426A35F0E66C65A258CF3C7 /* NSKeyedUnarchiver+Swift.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		F184A7BBBAD1D692BC451CE502BFB120 /* InfiniteSequence.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C22A1615527B150C21741AF1D991D24 /* InfiniteSequence.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F29B57BBC091455C916265CC763DA758 /* PriorityQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C254261A9FC83104DF1D24C33F31110 /* PriorityQueue.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F2B56C38AC34F501253BD69ACD625D93 /* Droste-umbrella.h in Headers */ = {isa = PBXBuildFile; fileRef = D2E263E33E01E12E632D7FE81BF1D949 /* Droste-umbrella.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		F2D512FE8E6A962E0630F127AB8A0489 /* FailureMessage.swift in Sources */ = {isa = PBXBuildFile; fileRef = 91E59896EDF05625CF489C9362A4C628 /* FailureMessage.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F34236CC526B8A4265F76F154ABF411D /* GroupedObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9223DEE14F4E1C27E97461952AADD3F /* GroupedObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F38DDC9F5FDFD26002229FD69C6C184C /* ThrowError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E18A7FF7CBDA9450CB94DEC9DC7F70 /* ThrowError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F38F0A4FBE7BFA39F834A31356D3C4DD /* Cache+Expire.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2875E2E9FD1B98E7176DDC0B2FAE62E8 /* Cache+Expire.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		F474BADFE74D089BED1A044C43441AE4 /* Create.swift in Sources */ = {isa = PBXBuildFile; fileRef = 780C8A5F17502180FDB54824FD3F810D /* Create.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F58C2663738975CE7FFE8C757F6D6296 /* MatchError.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9D1CE888EF874F9D96852F9371F34FEA /* MatchError.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F7D9BB3DBD269AB01C9A828F8ACBC836 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F92AF7638D9F00B37B06CFAC928BCC /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F8632FF906031D3939B941F6F6D7B00C /* QuickSpec.m in Sources */ = {isa = PBXBuildFile; fileRef = 446AA99E502C856B575FA5D1DCAC47B5 /* QuickSpec.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		F9153BFD39BA965E84128BD2D53349BF /* BeLessThanOrEqual.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0C47A86BF8ACB0C8A501B53C54125E6 /* BeLessThanOrEqual.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F49E24601477C82BE742A9321947D1DB /* ReuseInFlightTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 00EEE48D4847E059CB4847D288F402F7 /* ReuseInFlightTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F62783867EB6EBA359F4684D5FA129C5 /* ColdObservable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED1E5D67BF2841C2B6B8A7805B2BFB84 /* ColdObservable.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		F8D4195E99AE607828D5CDBF3B88C0E8 /* CwlCatchBadInstruction.swift in Sources */ = {isa = PBXBuildFile; fileRef = 26F92AF7638D9F00B37B06CFAC928BCC /* CwlCatchBadInstruction.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FA3656E16AE1779E1B1CF65F4691FB54 /* CurrentTestCaseTracker.h in Headers */ = {isa = PBXBuildFile; fileRef = 427A864D7DB8FDF816621B3A36D25152 /* CurrentTestCaseTracker.h */; settings = {ATTRIBUTES = (Private, ); }; };
+		FADADB00739B1964CAF0630ED5F0F354 /* SourceLocation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28089142BAB02F317AD1CA3C743F4161 /* SourceLocation.swift */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FAF36F05C93A5AA8F8CDCC7835E5A484 /* SingleAsync.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7FC31B2AEC5746A85819DD242B506042 /* SingleAsync.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FB44FA86A4D69274A16F794FE35E9312 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B56B25CE8220708F89E5D38D4DFB887F /* Foundation.framework */; };
 		FBBA1E4B4DBE81B4DCFDDE8E36061068 /* Completable+AndThen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1B7AC420CAE15DEB538D454C10292A84 /* Completable+AndThen.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FC04B2AE30A8B8DB7081F988578B6147 /* Quick.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 144AA2A04F9B8638D587586EC4E32F4A /* Quick.framework */; };
+		FCBFA50CEF06BD018C47FE7FEE363CAE /* NSBundle+CurrentTestBundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 178C07C7BE7B5B19970CE0A778488E18 /* NSBundle+CurrentTestBundle.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 		FD10B27E735E32FA6B8002F8F9C5DEEE /* ShareReplayScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 403CE64DFF46B860F390BF0D03A422D2 /* ShareReplayScope.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FECE46344B0F8264B338456378E0F027 /* Closures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 738135910E0064CB147B94B21A757452 /* Closures.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
-		FF9A344AF4EE62A205C4BD199AAEA5C1 /* QCKDSL.m in Sources */ = {isa = PBXBuildFile; fileRef = 27DCDEB24981E3CB732C4381FA626D10 /* QCKDSL.m */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FDA273564310BAEE61B963CDDA48E517 /* SalientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6D9FFCE7290B3DF322078B4968D8437A /* SalientTests.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FE54A3934661DF3D8068AD6283DEC6DE /* QuickSpecBase.h in Headers */ = {isa = PBXBuildFile; fileRef = 07B1B3A690A4215A45B8E138937F690C /* QuickSpecBase.h */; settings = {ATTRIBUTES = (Project, ); }; };
+		FEAF61813D3AFA3C6AE2CE60F164E83B /* NMBStringify.m in Sources */ = {isa = PBXBuildFile; fileRef = 935B7F52803202DC339031D5E9057028 /* NMBStringify.m */; settings = {COMPILER_FLAGS = "-DPRODUCT_NAME=Nimble/Nimble -w -Xanalyzer -analyzer-disable-all-checks"; }; };
+		FFA2BE12AD975CF3F83BB9CD059C7925 /* Example.swift in Sources */ = {isa = PBXBuildFile; fileRef = AAABE976D29E82D47711F15A1E106E8B /* Example.swift */; settings = {COMPILER_FLAGS = "-w -Xanalyzer -analyzer-disable-all-checks"; }; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
-		1199D1B5704D35AC623D1239C98E6403 /* PBXContainerItemProxy */ = {
+		10DC1DE2985CECE4EA0DBFB688195971 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
@@ -362,33 +363,40 @@
 			remoteGlobalIDString = 6BB8A926AFD1D0838DDCF56EF0045469;
 			remoteInfo = Droste;
 		};
-		891D036854C8540C4A334219AFB90811 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 9B3375A14D46317B1F3AE269C44D7F8A;
-			remoteInfo = RxTest;
-		};
-		A78C7A453F63DA606326A64B9E02C72E /* PBXContainerItemProxy */ = {
+		5AC75D0EEC58534ECA6FD275431139DE /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 6BB8A926AFD1D0838DDCF56EF0045469;
 			remoteInfo = Droste;
 		};
-		C0FC7C7F3EB8010BB106CC5937F46C30 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = A7635A015B61D26AF6E4B111CB69BDEF;
-			remoteInfo = Quick;
-		};
-		C5A4A845EA0C8EE670D1099DF84094C2 /* PBXContainerItemProxy */ = {
+		A39EE34BFA9B53DF40C599F31392A730 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
 			proxyType = 1;
 			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
 			remoteInfo = RxSwift;
+		};
+		A709B61DF98E4E76A32CF13F0912AA89 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = A03BA510876E6D21D3EF9757315DC91C;
+			remoteInfo = RxTest;
+		};
+		AC9001E92A9F33889CC030DFC331FA7A /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8B1C22EC32AE73C02516415C0152B402;
+			remoteInfo = Nimble;
+		};
+		C72A211515F118B4609C0162189C679E /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 8F6606D3EDE18A70E10FDC3AB59AC49A;
+			remoteInfo = Quick;
 		};
 		E7FAB65AEDCB1EDEF0569E45A618BDA4 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -397,24 +405,17 @@
 			remoteGlobalIDString = 70678CEEC2D6718B01A9E5A063E2A022;
 			remoteInfo = RxSwift;
 		};
-		F8F892A517324F6DD774820E501BBA41 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = D41D8CD98F00B204E9800998ECF8427E /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 20FA9B910D332A1809C9C2C423887904;
-			remoteInfo = Nimble;
-		};
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		00EEE48D4847E059CB4847D288F402F7 /* ReuseInFlightTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReuseInFlightTests.swift; sourceTree = "<group>"; };
 		01E6907CF2644EB1CF8E23F708A3DA0B /* Pods-Example-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Pods-Example-resources.sh"; sourceTree = "<group>"; };
 		02725AA6B05AACA955021B485CF40E0D /* Cache+SkipWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+SkipWhile.swift"; path = "Sources/Cache+SkipWhile.swift"; sourceTree = "<group>"; };
 		0424E1790219422B7EB6B251ED7429B0 /* SwitchIfEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwitchIfEmpty.swift; path = RxSwift/Observables/SwitchIfEmpty.swift; sourceTree = "<group>"; };
-		04477B7B6A9631203A96E716F9B8E4DF /* RxTest.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = RxTest.modulemap; sourceTree = "<group>"; };
+		04477B7B6A9631203A96E716F9B8E4DF /* RxTest.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = RxTest.modulemap; sourceTree = "<group>"; };
 		0549EB263233A4E143B87A2CB6B7DDED /* Behavior.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Behavior.swift; path = Sources/Quick/Behavior.swift; sourceTree = "<group>"; };
 		05B139738E8AB1BCB198F68731ED0053 /* Callsite.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Callsite.swift; path = Sources/Quick/Callsite.swift; sourceTree = "<group>"; };
 		06464B3E1258E03B1C46A2DD64028A76 /* Subscription.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Subscription.swift; path = RxTest/Subscription.swift; sourceTree = "<group>"; };
-		070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCacheTests.swift; sourceTree = "<group>"; };
 		075EB582A63C32140E7D9741CF677CA4 /* Enumerated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Enumerated.swift; path = RxSwift/Observables/Enumerated.swift; sourceTree = "<group>"; };
 		07B1B3A690A4215A45B8E138937F690C /* QuickSpecBase.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QuickSpecBase.h; path = Sources/QuickSpecBase/include/QuickSpecBase.h; sourceTree = "<group>"; };
 		0801686A5B36A736D3641815EE1D4204 /* RxTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RxTests.swift; path = RxTest/RxTests.swift; sourceTree = "<group>"; };
@@ -426,13 +427,14 @@
 		0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Quick.xcconfig; sourceTree = "<group>"; };
 		0A4250907D10CED5894873CB05B98773 /* Platform.Linux.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Linux.swift; path = Platform/Platform.Linux.swift; sourceTree = "<group>"; };
 		0CCEEF36C09885B713A3D7560E100904 /* CompositeCache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeCache.swift; path = Sources/CompositeCache.swift; sourceTree = "<group>"; };
+		0D968CBD8F99AB066F734268201544D7 /* SkipWhileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SkipWhileTests.swift; sourceTree = "<group>"; };
 		0E96538CB79CC8AF348E3364422431F4 /* ScheduledDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ScheduledDisposable.swift; path = RxSwift/Disposables/ScheduledDisposable.swift; sourceTree = "<group>"; };
 		0EE2787BAD6CAB49C44AC814A83A2ED6 /* SynchronizedDisposeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedDisposeType.swift; path = RxSwift/Concurrency/SynchronizedDisposeType.swift; sourceTree = "<group>"; };
 		0F54A3B30611A47020ECCDA28872E892 /* Queue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Queue.swift; path = Platform/DataStructures/Queue.swift; sourceTree = "<group>"; };
 		0F5F9FA62D15DA8072B6714CEFFDC103 /* Filter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Filter.swift; path = RxSwift/Observables/Filter.swift; sourceTree = "<group>"; };
 		108EFBCF28406ECBB643D5EC949493CF /* ObservableType+PrimitiveSequence.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "ObservableType+PrimitiveSequence.swift"; path = "RxSwift/Traits/ObservableType+PrimitiveSequence.swift"; sourceTree = "<group>"; };
 		11271157EE354CE9358AE9774380C0BC /* CombineLatest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CombineLatest.swift; path = RxSwift/Observables/CombineLatest.swift; sourceTree = "<group>"; };
-		119072C64A19799964E1620D83F514FB /* Pods-Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = "Pods-Example.modulemap"; sourceTree = "<group>"; };
+		119072C64A19799964E1620D83F514FB /* Pods-Example.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = "Pods-Example.modulemap"; sourceTree = "<group>"; };
 		144AA2A04F9B8638D587586EC4E32F4A /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		14688EEE13E18098791B2E48FF192795 /* RetryWhen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RetryWhen.swift; path = RxSwift/Observables/RetryWhen.swift; sourceTree = "<group>"; };
 		149054C495E8EC590CAB4C524133016F /* Pods-Example.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = "Pods-Example.debug.xcconfig"; sourceTree = "<group>"; };
@@ -440,7 +442,7 @@
 		15ADFD4E713416D860EAA5D3AB70052D /* Cache+ForwardRequest.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ForwardRequest.swift"; path = "Sources/Cache+ForwardRequest.swift"; sourceTree = "<group>"; };
 		178C07C7BE7B5B19970CE0A778488E18 /* NSBundle+CurrentTestBundle.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSBundle+CurrentTestBundle.swift"; path = "Sources/Quick/NSBundle+CurrentTestBundle.swift"; sourceTree = "<group>"; };
 		185AF272F0B6DA8C8F9441D231093075 /* Nimble.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Nimble.h; path = Sources/Nimble/Nimble.h; sourceTree = "<group>"; };
-		1A82A5891550F89601465A5DE5BB7434 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Quick.framework; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		1A82A5891550F89601465A5DE5BB7434 /* Quick.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Quick.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1B4F446ADE478C1C1E01A6DF2EAD0BEE /* Amb.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Amb.swift; path = RxSwift/Observables/Amb.swift; sourceTree = "<group>"; };
 		1B5ECA959FB88D251D51EB6430C7D29D /* TestScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestScheduler.swift; path = RxTest/Schedulers/TestScheduler.swift; sourceTree = "<group>"; };
 		1B7AC420CAE15DEB538D454C10292A84 /* Completable+AndThen.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Completable+AndThen.swift"; path = "RxSwift/Traits/Completable+AndThen.swift"; sourceTree = "<group>"; };
@@ -448,6 +450,7 @@
 		1CBB5EB74E0D9C84930C7438F7640E03 /* Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Rx.swift; path = RxSwift/Rx.swift; sourceTree = "<group>"; };
 		1D0D12CD7CA4FA31C47EA57756F53C78 /* DisposeBag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBag.swift; path = RxSwift/Disposables/DisposeBag.swift; sourceTree = "<group>"; };
 		1D8670ADBA31F83F75BA94F9ABA974F3 /* QuickSelectedTestSuiteBuilder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = QuickSelectedTestSuiteBuilder.swift; path = Sources/Quick/QuickSelectedTestSuiteBuilder.swift; sourceTree = "<group>"; };
+		1DA66BD11DFE1B44AEE8B3E87FE69247 /* ForwardRequestOperatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForwardRequestOperatorTests.swift; sourceTree = "<group>"; };
 		1F760993273BAFD1F853A8923273368A /* SuiteHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SuiteHooks.swift; path = Sources/Quick/Hooks/SuiteHooks.swift; sourceTree = "<group>"; };
 		20E8BD9801D9F2445DF683A261C21ABA /* Cache+Compose.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Compose.swift"; path = "Sources/Cache+Compose.swift"; sourceTree = "<group>"; };
 		21A8F7F09C9A6A330BD5F368C8609657 /* AllPass.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AllPass.swift; path = Sources/Nimble/Matchers/AllPass.swift; sourceTree = "<group>"; };
@@ -470,6 +473,7 @@
 		2D4916EB8BE4199D7627C169F2CA6B91 /* BeCloseTo.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeCloseTo.swift; path = Sources/Nimble/Matchers/BeCloseTo.swift; sourceTree = "<group>"; };
 		31F93BC7E647D0D2021806296CF59E89 /* RefCountDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = RefCountDisposable.swift; path = RxSwift/Disposables/RefCountDisposable.swift; sourceTree = "<group>"; };
 		34E8F0725F629126DB6F582017176D9C /* SynchronizedUnsubscribeType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SynchronizedUnsubscribeType.swift; path = RxSwift/Concurrency/SynchronizedUnsubscribeType.swift; sourceTree = "<group>"; };
+		350347333DA3AAD73E912D8327670F65 /* SwitchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwitchTests.swift; sourceTree = "<group>"; };
 		3517B45D9C3D29D33E054064596EC37D /* Sample.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Sample.swift; path = RxSwift/Observables/Sample.swift; sourceTree = "<group>"; };
 		374A0DAFD6D8FF7495CEBC805719A79A /* AssertionDispatcher.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionDispatcher.swift; path = Sources/Nimble/Adapters/AssertionDispatcher.swift; sourceTree = "<group>"; };
 		390947F0F397720A36AA2256A8B80572 /* SubscriptionDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SubscriptionDisposable.swift; path = RxSwift/Disposables/SubscriptionDisposable.swift; sourceTree = "<group>"; };
@@ -482,7 +486,7 @@
 		3D60A169920697B20C2D24FB59E5AD6E /* RxSwift-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RxSwift-dummy.m"; sourceTree = "<group>"; };
 		3EB2550B5110CA4FB9C6FD26836A6EBC /* Bag+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Bag+Rx.swift"; path = "RxSwift/Extensions/Bag+Rx.swift"; sourceTree = "<group>"; };
 		3F1884DFC444445AE3DAE8479FA02472 /* DisposeBase.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DisposeBase.swift; path = RxSwift/Disposables/DisposeBase.swift; sourceTree = "<group>"; };
-		3F2ED5FB51948C30205518DBA2717D88 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Quick.modulemap; sourceTree = "<group>"; };
+		3F2ED5FB51948C30205518DBA2717D88 /* Quick.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Quick.modulemap; sourceTree = "<group>"; };
 		3FC750EC952E121097BF47124F783F5E /* Caches.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Caches.swift; path = Sources/Caches.swift; sourceTree = "<group>"; };
 		403CE64DFF46B860F390BF0D03A422D2 /* ShareReplayScope.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ShareReplayScope.swift; path = RxSwift/Observables/ShareReplayScope.swift; sourceTree = "<group>"; };
 		4208096FBE5A3697F4691455C57A52A9 /* PriorityQueue.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PriorityQueue.swift; path = Platform/DataStructures/PriorityQueue.swift; sourceTree = "<group>"; };
@@ -494,6 +498,7 @@
 		452698D4DE0E21EA0996260EABB3D6AE /* CombineLatest+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CombineLatest+arity.swift"; path = "RxSwift/Observables/CombineLatest+arity.swift"; sourceTree = "<group>"; };
 		456AA1151E2EB02F7FE37EBBFE64EBA0 /* HistoricalSchedulerTimeConverter.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HistoricalSchedulerTimeConverter.swift; path = RxSwift/Schedulers/HistoricalSchedulerTimeConverter.swift; sourceTree = "<group>"; };
 		4737A1C81BBCB536D148DE95DAB3CEE9 /* Quick-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-prefix.pch"; sourceTree = "<group>"; };
+		4847C65728065B2E0B3B10E56917CA2F /* RetainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetainTests.swift; sourceTree = "<group>"; };
 		48DAE05351EC6B959EBA64BAF862395F /* DSL.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DSL.swift; path = Sources/Nimble/DSL.swift; sourceTree = "<group>"; };
 		49A1FD49CBC095971BF93E61BB94883D /* MainScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = MainScheduler.swift; path = RxSwift/Schedulers/MainScheduler.swift; sourceTree = "<group>"; };
 		49E18A7FF7CBDA9450CB94DEC9DC7F70 /* ThrowError.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ThrowError.swift; path = Sources/Nimble/Matchers/ThrowError.swift; sourceTree = "<group>"; };
@@ -518,7 +523,7 @@
 		59FDB452C5DFA7C19F6658D53AF9F8A3 /* Maybe.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Maybe.swift; path = RxSwift/Traits/Maybe.swift; sourceTree = "<group>"; };
 		5C57A36289AA8F980AA9BDB67D172505 /* Cache+ReuseInFlight.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+ReuseInFlight.swift"; path = "Sources/Cache+ReuseInFlight.swift"; sourceTree = "<group>"; };
 		5CDEDF71C13611D83ACF75918250AB50 /* Optional.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Optional.swift; path = RxSwift/Observables/Optional.swift; sourceTree = "<group>"; };
-		5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
+		5D7A9F09E0A5293FE5EBCC6C17FFFEFF /* mach_excServer.c */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.c; name = mach_excServer.c; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/mach_excServer.c; sourceTree = "<group>"; };
 		5E71AEC51B010BB3D5AB352ACFBB17BE /* PostNotification.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = PostNotification.swift; path = Sources/Nimble/Matchers/PostNotification.swift; sourceTree = "<group>"; };
 		5E74A6E007520ECCE695064780621BC4 /* String+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "String+Rx.swift"; path = "RxSwift/Extensions/String+Rx.swift"; sourceTree = "<group>"; };
 		605139D9F86CB74500BF0C1D13A2484B /* Async.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Async.swift; path = Sources/Nimble/Utils/Async.swift; sourceTree = "<group>"; };
@@ -527,6 +532,7 @@
 		61F77F4B181B08425951C1175E1C5714 /* CombineLatest+Collection.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "CombineLatest+Collection.swift"; path = "RxSwift/Observables/CombineLatest+Collection.swift"; sourceTree = "<group>"; };
 		624AE40A0FCA86E1F3E1D79669BAF589 /* Dematerialize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Dematerialize.swift; path = RxSwift/Observables/Dematerialize.swift; sourceTree = "<group>"; };
 		64299BE07801777F3AD2B98E369C01A5 /* CwlDarwinDefinitions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlDarwinDefinitions.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlDarwinDefinitions.swift; sourceTree = "<group>"; };
+		6433A35C5237951780F71007CDD7CAF6 /* ExpireTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ExpireTests.swift; sourceTree = "<group>"; };
 		647E651ED7B69A270E297A1E2E9976BC /* SchedulerServices+Emulation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "SchedulerServices+Emulation.swift"; path = "RxSwift/Schedulers/SchedulerServices+Emulation.swift"; sourceTree = "<group>"; };
 		654A93D8653FA5EF9411A69B18AB621F /* Never.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Never.swift; path = RxSwift/Observables/Never.swift; sourceTree = "<group>"; };
 		65C1CFBF23986F7F678D8874DF9471E6 /* Error.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Error.swift; path = RxSwift/Observables/Error.swift; sourceTree = "<group>"; };
@@ -537,12 +543,13 @@
 		699118D7DDD5F335E4FB8B17DC0F12D2 /* Pods-Example-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Pods-Example-dummy.m"; sourceTree = "<group>"; };
 		6AFD76D04B1BF859FA77E7363C393977 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		6C666618A086B6BC13A87EEEC55D5051 /* BeginWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeginWith.swift; path = Sources/Nimble/Matchers/BeginWith.swift; sourceTree = "<group>"; };
-		6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ForwardRequestOperatorTests.swift; sourceTree = "<group>"; };
+		6D9FFCE7290B3DF322078B4968D8437A /* SalientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SalientTests.swift; sourceTree = "<group>"; };
 		6DB5546987339D3006C11834A93DA985 /* CwlBadInstructionException.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CwlBadInstructionException.swift; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlPreconditionTesting/CwlBadInstructionException.swift; sourceTree = "<group>"; };
+		6EEABCAB89B88547BEBA17DF0A3C9CC5 /* MapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		6F4CCF58DC99E09361656CDEB3F969AB /* Merge.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Merge.swift; path = RxSwift/Observables/Merge.swift; sourceTree = "<group>"; };
 		6F89C69F00F905174B0FFBEBF16B23AC /* NMBExceptionCapture.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBExceptionCapture.h; path = Sources/NimbleObjectiveC/NMBExceptionCapture.h; sourceTree = "<group>"; };
 		6FDE67C898D6218C71BCA27B4970A5A1 /* Match.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Match.swift; path = Sources/Nimble/Matchers/Match.swift; sourceTree = "<group>"; };
-		6FE326DFA47E41B7CD91300BAA54C629 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Nimble.framework; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		6FE326DFA47E41B7CD91300BAA54C629 /* Nimble.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Nimble.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		70C2CDFAEC61EFDD038EE89B7310CBAD /* StartWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = StartWith.swift; path = RxSwift/Observables/StartWith.swift; sourceTree = "<group>"; };
 		70E7A942D578B7C36F0279DB99E36AF0 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		71E48E4CFF3E795C7F7FC6C05461A260 /* CwlMachBadInstructionHandler.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlMachBadInstructionHandler.m; path = Carthage/Checkouts/CwlPreconditionTesting/Sources/CwlMachBadInstructionHandler/CwlMachBadInstructionHandler.m; sourceTree = "<group>"; };
@@ -562,7 +569,7 @@
 		7A9E11AB03A3F11B7AFB7A0D0F19A0B3 /* Expectation.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Expectation.swift; path = Sources/Nimble/Expectation.swift; sourceTree = "<group>"; };
 		7AFC985C0C75E35B4A6AE383A847DCC5 /* ToSucceed.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ToSucceed.swift; path = Sources/Nimble/Matchers/ToSucceed.swift; sourceTree = "<group>"; };
 		7B9A6A90586B5D6FF6007D3A8CAE078A /* Generate.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Generate.swift; path = RxSwift/Observables/Generate.swift; sourceTree = "<group>"; };
-		7D68E41227D7A34AF26E48499DEA8D54 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxTest.framework; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		7D68E41227D7A34AF26E48499DEA8D54 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		7E16CB41EEE80933DC59102A1CF876EA /* NimbleXCTestHandler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NimbleXCTestHandler.swift; path = Sources/Nimble/Adapters/NimbleXCTestHandler.swift; sourceTree = "<group>"; };
 		7E67A0D7B7413977E91583D48768D24B /* Cache.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cache.swift; path = Sources/Cache.swift; sourceTree = "<group>"; };
 		7E91B5759B010D20E06F6FDC133675F5 /* ReplaySubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ReplaySubject.swift; path = RxSwift/Subjects/ReplaySubject.swift; sourceTree = "<group>"; };
@@ -575,7 +582,6 @@
 		8328E7C0D6403714ECE7338CC9440073 /* CompositeDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = CompositeDisposable.swift; path = RxSwift/Disposables/CompositeDisposable.swift; sourceTree = "<group>"; };
 		834ED52643B582A82D56536389F11FA6 /* World+DSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = "World+DSL.h"; path = "Sources/QuickObjectiveC/DSL/World+DSL.h"; sourceTree = "<group>"; };
 		83EE71F0FE105E79407BC049D2A38772 /* ConnectableObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConnectableObservableType.swift; path = RxSwift/ConnectableObservableType.swift; sourceTree = "<group>"; };
-		843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionTests.swift; sourceTree = "<group>"; };
 		8565A00AAA29127E3A316E9921DBE732 /* RxTest.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxTest.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		889F73266A196B3FE3BB0537221C3009 /* Do.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Do.swift; path = RxSwift/Observables/Do.swift; sourceTree = "<group>"; };
 		88AE06D808F2F25DAA9F9ACDF64372B7 /* Materialize.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Materialize.swift; path = RxSwift/Observables/Materialize.swift; sourceTree = "<group>"; };
@@ -591,16 +597,14 @@
 		8CAE7C2A80A89C089E3A118C05B6E405 /* TakeWhile.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeWhile.swift; path = RxSwift/Observables/TakeWhile.swift; sourceTree = "<group>"; };
 		8D7DD93F264BC535D061EC8536AE9D8B /* NSString+C99ExtendedIdentifier.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "NSString+C99ExtendedIdentifier.swift"; path = "Sources/Quick/NSString+C99ExtendedIdentifier.swift"; sourceTree = "<group>"; };
 		8D993FEFA0466F8C553B6AAF5A4F255F /* GroupBy.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = GroupBy.swift; path = RxSwift/Observables/GroupBy.swift; sourceTree = "<group>"; };
-		8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = MapTests.swift; sourceTree = "<group>"; };
 		8EA39E9E71A1FC29AA92E535D177682F /* Nimble-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Nimble-umbrella.h"; sourceTree = "<group>"; };
 		8FA7D068830C8E38B73913ABA551D6AA /* TakeLast.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TakeLast.swift; path = RxSwift/Observables/TakeLast.swift; sourceTree = "<group>"; };
 		90117FABAAFBA5499FEFE1ADD97272AC /* Zip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Zip.swift; path = RxSwift/Observables/Zip.swift; sourceTree = "<group>"; };
 		905B102093BA04370529D8C3EFE29F80 /* CwlCatchException.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = CwlCatchException.m; path = Carthage/Checkouts/CwlCatchException/Sources/CwlCatchExceptionSupport/CwlCatchException.m; sourceTree = "<group>"; };
 		9155700584B15494789BDEBBB7A47EA8 /* Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Extensions.swift; path = Sources/Extensions.swift; sourceTree = "<group>"; };
 		91E59896EDF05625CF489C9362A4C628 /* FailureMessage.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = FailureMessage.swift; path = Sources/Nimble/FailureMessage.swift; sourceTree = "<group>"; };
-		933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ReuseInFlightTests.swift; sourceTree = "<group>"; };
 		935B7F52803202DC339031D5E9057028 /* NMBStringify.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = NMBStringify.m; path = Sources/NimbleObjectiveC/NMBStringify.m; sourceTree = "<group>"; };
-		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; lastKnownFileType = text; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
+		93A4A3777CF96A4AAC1D13BA6DCCEA73 /* Podfile */ = {isa = PBXFileReference; explicitFileType = text.script.ruby; includeInIndex = 1; name = Podfile; path = ../Podfile; sourceTree = SOURCE_ROOT; xcLanguageSpecificationIdentifier = xcode.lang.ruby; };
 		95332C62694E7BDC87A33226B19B43C5 /* Reactive.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reactive.swift; path = RxSwift/Reactive.swift; sourceTree = "<group>"; };
 		9761F27F54E78828A2B807DAB2A25879 /* ExampleHooks.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleHooks.swift; path = Sources/Quick/Hooks/ExampleHooks.swift; sourceTree = "<group>"; };
 		981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "XCTest+Rx.swift"; path = "RxTest/XCTest+Rx.swift"; sourceTree = "<group>"; };
@@ -620,8 +624,8 @@
 		A01B9AC2AE3E5160F770D7E24A360B21 /* AnonymousObserver.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AnonymousObserver.swift; path = RxSwift/Observers/AnonymousObserver.swift; sourceTree = "<group>"; };
 		A0D122B4BB2E236A54975BD2A0227F3A /* Range.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Range.swift; path = RxSwift/Observables/Range.swift; sourceTree = "<group>"; };
 		A2A73C789D855DEF04139E173F02CE64 /* RxTest-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "RxTest-dummy.m"; sourceTree = "<group>"; };
+		A2ACB9B1E7C386D1C65F90BD7539B766 /* RamCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RamCacheTests.swift; sourceTree = "<group>"; };
 		A4D65DACD5C31C293EF363C0753AB08F /* Droste-Unit-Tests-frameworks.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-frameworks.sh"; sourceTree = "<group>"; };
-		A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SalientTests.swift; sourceTree = "<group>"; };
 		A58E0F0B1A3B6F28663FC08EB3ACDE78 /* Repeat.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Repeat.swift; path = RxSwift/Observables/Repeat.swift; sourceTree = "<group>"; };
 		A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Nimble.xcconfig; sourceTree = "<group>"; };
 		A5DF324C6A2B21E73811CBF46C7D33FA /* ObservableType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableType.swift; path = RxSwift/ObservableType.swift; sourceTree = "<group>"; };
@@ -641,8 +645,8 @@
 		AF17E0B9D2E8682E672520F4CCA1E0C4 /* Quick.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = Quick.h; path = Sources/QuickObjectiveC/Quick.h; sourceTree = "<group>"; };
 		AF9AF554228C539C0AD66F41BFA9CC1C /* Debug.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Debug.swift; path = RxSwift/Observables/Debug.swift; sourceTree = "<group>"; };
 		B0FF8963A749934021EE631E46FA8D10 /* Debounce.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Debounce.swift; path = RxSwift/Observables/Debounce.swift; sourceTree = "<group>"; };
-		B20D338C109FC605D3EDC5233AC69F1A /* Droste.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Droste.framework; path = Droste.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B24A970D82A76D52A7B0E727F6100AC6 /* RxSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = RxSwift.modulemap; sourceTree = "<group>"; };
+		B20D338C109FC605D3EDC5233AC69F1A /* Droste.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Droste.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B24A970D82A76D52A7B0E727F6100AC6 /* RxSwift.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = RxSwift.modulemap; sourceTree = "<group>"; };
 		B319C2062C21BF38BC241BE0C439F296 /* DefaultIfEmpty.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = DefaultIfEmpty.swift; path = RxSwift/Observables/DefaultIfEmpty.swift; sourceTree = "<group>"; };
 		B3389D1AE2E13C76B4B14E029DCC420A /* SerialDispatchQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SerialDispatchQueueScheduler.swift; path = RxSwift/Schedulers/SerialDispatchQueueScheduler.swift; sourceTree = "<group>"; };
 		B36C37D0620E19DE982B14EE97CB492D /* PrimitiveSequence+Zip+arity.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "PrimitiveSequence+Zip+arity.swift"; path = "RxSwift/Traits/PrimitiveSequence+Zip+arity.swift"; sourceTree = "<group>"; };
@@ -655,38 +659,39 @@
 		B8FF8CF506C383DA0B139B097FCBADB1 /* Errors.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Errors.swift; path = RxSwift/Errors.swift; sourceTree = "<group>"; };
 		B9677E9E790094792357AB00A80B5F99 /* Deferred.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deferred.swift; path = RxSwift/Observables/Deferred.swift; sourceTree = "<group>"; };
 		BA43064F9A852B1B6860BCE449DFB169 /* Quick-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Quick-umbrella.h"; sourceTree = "<group>"; };
+		BB15D4B650BF63162F7CD9FF7E2558F9 /* DiskCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
 		BB6F135951F0F23BEDF8068C9C66C27D /* ImmediateSchedulerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ImmediateSchedulerType.swift; path = RxSwift/ImmediateSchedulerType.swift; sourceTree = "<group>"; };
 		BD4550F0446F62D284F47CECFFB7CF7C /* QCKDSL.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = QCKDSL.h; path = Sources/QuickObjectiveC/DSL/QCKDSL.h; sourceTree = "<group>"; };
 		BD4A59E727AA546B89DF4132569CD49F /* DSL.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; name = DSL.m; path = Sources/NimbleObjectiveC/DSL.m; sourceTree = "<group>"; };
 		BE9A2F5B4931E44B6F1B80415CAFE81D /* RxSwift-prefix.pch */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "RxSwift-prefix.pch"; sourceTree = "<group>"; };
-		BEF0FBAC1203B679D3196FB350EC0F80 /* Droste.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Droste.modulemap; sourceTree = "<group>"; };
+		BEF0FBAC1203B679D3196FB350EC0F80 /* Droste.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Droste.modulemap; sourceTree = "<group>"; };
 		BF1E96B4FCF763CCF5848F3A04BDEE3C /* AssertionRecorder.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AssertionRecorder.swift; path = Sources/Nimble/Adapters/AssertionRecorder.swift; sourceTree = "<group>"; };
+		BFC198862F343DAE257E3514E8D69763 /* CacheFake.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CacheFake.swift; sourceTree = "<group>"; };
 		C036E198D7FA1F251CE2C2D623B8EC20 /* Deprecated.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Deprecated.swift; path = RxTest/Deprecated.swift; sourceTree = "<group>"; };
 		C0D2F869E070B98513E85F2F7921AEAC /* Platform.Linux.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Linux.swift; path = Platform/Platform.Linux.swift; sourceTree = "<group>"; };
 		C162ADAA8658A02659DCAC1E8364D596 /* ConcurrentDispatchQueueScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentDispatchQueueScheduler.swift; path = RxSwift/Schedulers/ConcurrentDispatchQueueScheduler.swift; sourceTree = "<group>"; };
 		C1991D26BBA8ECCC498748FF0B412153 /* Info.plist */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		C20112E2D057B83282A63E76E8FA565D /* SingleAssignmentDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SingleAssignmentDisposable.swift; path = RxSwift/Disposables/SingleAssignmentDisposable.swift; sourceTree = "<group>"; };
 		C2AF68BE3CB6608B515CE233AD8231A2 /* EndWith.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = EndWith.swift; path = Sources/Nimble/Matchers/EndWith.swift; sourceTree = "<group>"; };
-		C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = DiskCacheTests.swift; sourceTree = "<group>"; };
 		C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; path = Droste.xcconfig; sourceTree = "<group>"; };
 		C616271A38C3EEDFCB5D35828D794B2F /* Disposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Disposable.swift; path = RxSwift/Disposable.swift; sourceTree = "<group>"; };
 		C656FB4C600D0B66A0CA26EA3CA1C6B6 /* VirtualTimeConverterType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = VirtualTimeConverterType.swift; path = RxSwift/Schedulers/VirtualTimeConverterType.swift; sourceTree = "<group>"; };
 		C65B7F488687567D2AD4AEB111AAB8BA /* Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Switch.swift; path = RxSwift/Observables/Switch.swift; sourceTree = "<group>"; };
 		C7181441ED03EE29184C112B38209E46 /* Single.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Single.swift; path = RxSwift/Traits/Single.swift; sourceTree = "<group>"; };
 		C7FD76819C1FCE81806064C89E577597 /* Catch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Catch.swift; path = RxSwift/Observables/Catch.swift; sourceTree = "<group>"; };
+		C8527356AC567E100A57C036BD72B60D /* CompositionTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CompositionTests.swift; sourceTree = "<group>"; };
 		C855E1F240198863501B0AD4F112A227 /* LockOwnerType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = LockOwnerType.swift; path = RxSwift/Concurrency/LockOwnerType.swift; sourceTree = "<group>"; };
-		C86A7256BBD447D4F4C456049B2C581F /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; path = Nimble.modulemap; sourceTree = "<group>"; };
+		C86A7256BBD447D4F4C456049B2C581F /* Nimble.modulemap */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.module-map"; path = Nimble.modulemap; sourceTree = "<group>"; };
 		C8A6EF2A5694A31A5CDF6AF7E7B00AC8 /* Any+Equatable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Any+Equatable.swift"; path = "RxTest/Any+Equatable.swift"; sourceTree = "<group>"; };
 		C9535482AAB6042AA7B9F4708C95A8F1 /* BinaryDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BinaryDisposable.swift; path = RxSwift/Disposables/BinaryDisposable.swift; sourceTree = "<group>"; };
 		C9BDE82371C83FA9AE91B05F77ACAA36 /* Pods-Example-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Pods-Example-umbrella.h"; sourceTree = "<group>"; };
 		C9DEF6971B000CB7E6C2A7079CD93E15 /* BeAKindOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAKindOf.swift; path = Sources/Nimble/Matchers/BeAKindOf.swift; sourceTree = "<group>"; };
 		C9DF150BFE695968F04236FFF189878F /* BeAnInstanceOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeAnInstanceOf.swift; path = Sources/Nimble/Matchers/BeAnInstanceOf.swift; sourceTree = "<group>"; };
 		CB075012E5CF90FC620CE801F83F7E12 /* NMBStringify.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; name = NMBStringify.h; path = Sources/NimbleObjectiveC/NMBStringify.h; sourceTree = "<group>"; };
-		CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SkipWhileTests.swift; sourceTree = "<group>"; };
 		CDFACB25ABE7EF55F68113515C4ED284 /* NopDisposable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = NopDisposable.swift; path = RxSwift/Disposables/NopDisposable.swift; sourceTree = "<group>"; };
 		CE18E0BFD2918C0E3F1B5AB26CA5D95F /* Take.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Take.swift; path = RxSwift/Observables/Take.swift; sourceTree = "<group>"; };
 		CF9FA296A61F02C71E067B65E060AF9A /* ObservableConvertibleType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObservableConvertibleType.swift; path = RxSwift/ObservableConvertibleType.swift; sourceTree = "<group>"; };
-		D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = RxSwift.framework; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = RxSwift.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		D220738394C885CAE465F0CC85974514 /* Window.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Window.swift; path = RxSwift/Observables/Window.swift; sourceTree = "<group>"; };
 		D2E263E33E01E12E632D7FE81BF1D949 /* Droste-umbrella.h */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.h; path = "Droste-umbrella.h"; sourceTree = "<group>"; };
 		D387B98D28FA4514045F6432CBED5199 /* XCTest.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = XCTest.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS10.3.sdk/System/Library/Frameworks/XCTest.framework; sourceTree = DEVELOPER_DIR; };
@@ -698,7 +703,6 @@
 		D56DA18B320AAC1740C443786FDBB024 /* SwiftSupport.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SwiftSupport.swift; path = RxSwift/SwiftSupport/SwiftSupport.swift; sourceTree = "<group>"; };
 		D618449AFC6917EC84F2472DDF576D19 /* SatisfyAnyOf.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = SatisfyAnyOf.swift; path = Sources/Nimble/Matchers/SatisfyAnyOf.swift; sourceTree = "<group>"; };
 		D6E1FCBDFE3DD9AF98DAA6B0274E8048 /* ExampleGroup.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ExampleGroup.swift; path = Sources/Quick/ExampleGroup.swift; sourceTree = "<group>"; };
-		D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SwitchTests.swift; sourceTree = "<group>"; };
 		D8771C43A89854E33143BC1E490E982F /* Reduce.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Reduce.swift; path = RxSwift/Observables/Reduce.swift; sourceTree = "<group>"; };
 		D87C44A47BD0F817D12FDE011002A153 /* Cache+Switch.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "Cache+Switch.swift"; path = "Sources/Cache+Switch.swift"; sourceTree = "<group>"; };
 		D8B189A16C05A14C69624B1D23DEAB3C /* AsyncLock.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AsyncLock.swift; path = RxSwift/Concurrency/AsyncLock.swift; sourceTree = "<group>"; };
@@ -719,7 +723,7 @@
 		DFC2626B8358940692B134A160E14C32 /* Cancelable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Cancelable.swift; path = RxSwift/Cancelable.swift; sourceTree = "<group>"; };
 		DFCDCCD2CB84A44273B4917DA700515E /* Bag.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Bag.swift; path = Platform/DataStructures/Bag.swift; sourceTree = "<group>"; };
 		DFE9A9B5D9C6D7155ED2F3AF4A912C26 /* HaveCount.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = HaveCount.swift; path = Sources/Nimble/Matchers/HaveCount.swift; sourceTree = "<group>"; };
-		DFF18FC4C0C1A5B0FFDBCFB18A5AC2F8 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; name = Pods_Example.framework; path = "Pods-Example.framework"; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFF18FC4C0C1A5B0FFDBCFB18A5AC2F8 /* Pods_Example.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Example.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		E02932E0F16695277F04D1B0CA7FA2C2 /* Platform.Darwin.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Platform.Darwin.swift; path = Platform/Platform.Darwin.swift; sourceTree = "<group>"; };
 		E03A8B108B52F54A50E12C0F9ABB0C2F /* AddRef.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = AddRef.swift; path = RxSwift/Observables/AddRef.swift; sourceTree = "<group>"; };
 		E2F6B103DE3F9F97F83E6C476C1B16C5 /* Skip.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = Skip.swift; path = RxSwift/Observables/Skip.swift; sourceTree = "<group>"; };
@@ -745,7 +749,6 @@
 		F099B690CEC2A42B92999FF085FBD9EC /* BeNil.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeNil.swift; path = Sources/Nimble/Matchers/BeNil.swift; sourceTree = "<group>"; };
 		F0C47A86BF8ACB0C8A501B53C54125E6 /* BeLessThanOrEqual.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BeLessThanOrEqual.swift; path = Sources/Nimble/Matchers/BeLessThanOrEqual.swift; sourceTree = "<group>"; };
 		F17F7E7A63184E5A88028E15CD2EAC1A /* Droste-Unit-Tests */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; name = "Droste-Unit-Tests"; path = "Droste-Unit-Tests.xctest"; sourceTree = BUILT_PRODUCTS_DIR; };
-		F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RetainTests.swift; sourceTree = "<group>"; };
 		F1D1B3DDDC079647155BC0893F747601 /* ObserverType.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ObserverType.swift; path = RxSwift/ObserverType.swift; sourceTree = "<group>"; };
 		F2B3ACC3A810F1D86386DC66DD864706 /* ConcurrentMainScheduler.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = ConcurrentMainScheduler.swift; path = RxSwift/Schedulers/ConcurrentMainScheduler.swift; sourceTree = "<group>"; };
 		F31CCA18D26542150A91E23A17BA3784 /* Droste-Unit-Tests-resources.sh */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.script.sh; path = "Droste-Unit-Tests-resources.sh"; sourceTree = "<group>"; };
@@ -756,7 +759,6 @@
 		F75861FD8178EE58B01ECD63DD21C67D /* URL+FileName.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "URL+FileName.swift"; path = "Sources/Quick/URL+FileName.swift"; sourceTree = "<group>"; };
 		F8590B74B6F82B567F528AF587959257 /* DispatchQueue+Extensions.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = "DispatchQueue+Extensions.swift"; path = "Platform/DispatchQueue+Extensions.swift"; sourceTree = "<group>"; };
 		F93367B5FFE412E86E6141363502F1B4 /* ConcurrentDictionary.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ConcurrentDictionary.swift; sourceTree = "<group>"; };
-		F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = CacheFake.swift; sourceTree = "<group>"; };
 		F97A167AE3E61565ABFF1430236CD2CE /* TestableObservable.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = TestableObservable.swift; path = RxTest/TestableObservable.swift; sourceTree = "<group>"; };
 		FAD19357A80957099904472A89B7FA0D /* Nimble-dummy.m */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.c.objc; path = "Nimble-dummy.m"; sourceTree = "<group>"; };
 		FC3DD92AFC2E510C7B449FED87EDCE01 /* BehaviorSubject.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; name = BehaviorSubject.swift; path = RxSwift/Subjects/BehaviorSubject.swift; sourceTree = "<group>"; };
@@ -780,34 +782,24 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		201DE67D5B046ECB820E5F6F8B1B1399 /* Frameworks */ = {
+		5A7B9F9B8BDDEDE6FC4008E8FC472478 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				C6EE3EBFB01CBC1D9906A7A7E4FBEED1 /* Foundation.framework in Frameworks */,
-				C357FB2E6BC6670AA2AF6DE89F5888F4 /* RxSwift.framework in Frameworks */,
-				B453A74BA45777678EA48C8167C550C5 /* XCTest.framework in Frameworks */,
+				FB44FA86A4D69274A16F794FE35E9312 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		3FF48FCE927D8B3D2C6F65490F1C4906 /* Frameworks */ = {
+		6C9191EF7770F6CD54361D1A85AABDB5 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				55ED80AC201E95BA04B5DC8CF05F537B /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		9F1BC7D19013905316702D04EB65A60B /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				D0349514048A756AD550ED37322ED591 /* Droste.framework in Frameworks */,
-				7E8B959FC0E11ADE51DE16EE46D40F16 /* Foundation.framework in Frameworks */,
-				9B956F87081C78FE2142CB966A82C286 /* Nimble.framework in Frameworks */,
-				FC04B2AE30A8B8DB7081F988578B6147 /* Quick.framework in Frameworks */,
-				4A0774063C4895027EDC5542CF7995EE /* RxSwift.framework in Frameworks */,
-				4D80D9E6AFD7C9745D7FD55AEE345317 /* RxTest.framework in Frameworks */,
+				62FA8B8420F4213B31E5A1C4688F0EFA /* Droste.framework in Frameworks */,
+				E97A6C3D69EA07CF23194E38920F88AA /* Foundation.framework in Frameworks */,
+				6157E82919CAAB844BE2E31AE397A0BA /* Nimble.framework in Frameworks */,
+				DCE66E389058625109957CB220D66ED6 /* Quick.framework in Frameworks */,
+				BB99054FD78CF548A1A39EA67BBC5ECD /* RxSwift.framework in Frameworks */,
+				A4719B47039DAA3C1834E3C842757861 /* RxTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -819,20 +811,30 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		CCA6D21BC0A0E6C93A153437894B1DEF /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				2E302D4719721C7ACAEE1C0FF92F288D /* Foundation.framework in Frameworks */,
+				3235D9456CB5346F22E9D7903078656C /* RxSwift.framework in Frameworks */,
+				0EFB98E8D2124B6CA9701C6EED622D31 /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		CCF37D35FDF14353A1DAA792F81B91E1 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				966CC50694AC798D8DFAE8AC4138571B /* Foundation.framework in Frameworks */,
+				11CAC00690EF608FFD244013E7C4849B /* XCTest.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		E399D196CB84CAE0DB048A348961747C /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
 				04C241623428C470EC9A647F5CCAFF18 /* Foundation.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		F7410D6EAF182222F51B4A756C0E721D /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				53892A7B91F7D479A1533E8774CB60A9 /* Foundation.framework in Frameworks */,
-				BA39B670C01B024FA6756E32A48280BE /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -847,6 +849,15 @@
 			);
 			name = Fetchers;
 			path = Sources/Fetchers;
+			sourceTree = "<group>";
+		};
+		0E581F58326C7A3F4EEB5758714D2F78 /* Tests */ = {
+			isa = PBXGroup;
+			children = (
+				A6B1561833DE8A6FC58D410E052BECA8 /* Sources */,
+				E97ACFCD133B929B306D596FFBEA6EB0 /* Tests */,
+			);
+			name = Tests;
 			sourceTree = "<group>";
 		};
 		0E9D1BA20417C75FD2F7CB91830D244F /* Droste */ = {
@@ -872,7 +883,7 @@
 				00A5295DD9ECE5D0CF95C40C039D6659 /* Fetchers */,
 				1488191D420D5F1A7834E9571F0BB616 /* Helpers */,
 				5CE576F56F7C309D31DCE8C8CE94136C /* Support Files */,
-				5173ACD094B782A7D5AE393F1FE84F17 /* Tests */,
+				0E581F58326C7A3F4EEB5758714D2F78 /* Tests */,
 			);
 			name = Droste;
 			path = ../..;
@@ -1053,7 +1064,6 @@
 				9AA1890ABEC35BB449F3F5683C6B2425 /* Zip+Collection.swift */,
 				2E4DEB15C191B9F4BCE65C9F1E8C434A /* Support Files */,
 			);
-			name = RxSwift;
 			path = RxSwift;
 			sourceTree = "<group>";
 		};
@@ -1131,7 +1141,6 @@
 				3AA58C96DBD798CAE5DFC169065D36EB /* XCTestObservationCenter+Register.m */,
 				B6D27D2CBB2B65B4653CE8A33482A7C2 /* Support Files */,
 			);
-			name = Nimble;
 			path = Nimble;
 			sourceTree = "<group>";
 		};
@@ -1158,15 +1167,6 @@
 				6E1D3F899F37CDD6F95A5C602CB93B05 /* RxTest */,
 			);
 			name = Pods;
-			sourceTree = "<group>";
-		};
-		5173ACD094B782A7D5AE393F1FE84F17 /* Tests */ = {
-			isa = PBXGroup;
-			children = (
-				C99619C8783FD836C22CB497FD15FBFF /* Sources */,
-				FC9BEFA41E09286ACFB0C8B11E6008AF /* Tests */,
-			);
-			name = Tests;
 			sourceTree = "<group>";
 		};
 		5CE576F56F7C309D31DCE8C8CE94136C /* Support Files */ = {
@@ -1221,7 +1221,6 @@
 				981C6704C7DF9A5DD2EF4C257D57440E /* XCTest+Rx.swift */,
 				A63D23653B8EAEA8C0AEF695D16EDD4D /* Support Files */,
 			);
-			name = RxTest;
 			path = RxTest;
 			sourceTree = "<group>";
 		};
@@ -1315,7 +1314,6 @@
 				9A1F97F9E0F5FA166C24534977251F38 /* XCTestSuite+QuickTestSuiteBuilder.m */,
 				8B2F60C18D76EB4C2A8BDEB31F64BD9D /* Support Files */,
 			);
-			name = Quick;
 			path = Quick;
 			sourceTree = "<group>";
 		};
@@ -1333,6 +1331,13 @@
 			path = "../Target Support Files/RxTest";
 			sourceTree = "<group>";
 		};
+		A6B1561833DE8A6FC58D410E052BECA8 /* Sources */ = {
+			isa = PBXGroup;
+			children = (
+			);
+			path = Sources;
+			sourceTree = "<group>";
+		};
 		B6D27D2CBB2B65B4653CE8A33482A7C2 /* Support Files */ = {
 			isa = PBXGroup;
 			children = (
@@ -1345,14 +1350,6 @@
 			);
 			name = "Support Files";
 			path = "../Target Support Files/Nimble";
-			sourceTree = "<group>";
-		};
-		C99619C8783FD836C22CB497FD15FBFF /* Sources */ = {
-			isa = PBXGroup;
-			children = (
-			);
-			name = Sources;
-			path = Sources;
 			sourceTree = "<group>";
 		};
 		D1D64EC400620608537E1A15682BB148 /* Products */ = {
@@ -1369,22 +1366,22 @@
 			name = Products;
 			sourceTree = "<group>";
 		};
-		FC9BEFA41E09286ACFB0C8B11E6008AF /* Tests */ = {
+		E97ACFCD133B929B306D596FFBEA6EB0 /* Tests */ = {
 			isa = PBXGroup;
 			children = (
-				F9584DE6DF04BA623DB11063DCB40F50 /* CacheFake.swift */,
-				843AD4F16C6711E76DE46EEE04BF2C21 /* CompositionTests.swift */,
-				C4D2DCE9FD5717E79065CA5C86617798 /* DiskCacheTests.swift */,
-				6CCC33257F98F708E9975F4BA6E35852 /* ForwardRequestOperatorTests.swift */,
-				8DDE6A37C62BFE094409ECE9811B1C9D /* MapTests.swift */,
-				070AD908BC3CF9D1BB9C8CA6B7299E6F /* RamCacheTests.swift */,
-				F1AEABE65F43F1ADE48E388954F7F8BB /* RetainTests.swift */,
-				933847FC96EAC81759E372F992186728 /* ReuseInFlightTests.swift */,
-				A4F5521F87D66A2E8E34D2FE04010361 /* SalientTests.swift */,
-				CB6324D5FC2553FCFA4FB0428C52FC2D /* SkipWhileTests.swift */,
-				D778D7109CFE3FA4EA8A995C9585D981 /* SwitchTests.swift */,
+				BFC198862F343DAE257E3514E8D69763 /* CacheFake.swift */,
+				C8527356AC567E100A57C036BD72B60D /* CompositionTests.swift */,
+				BB15D4B650BF63162F7CD9FF7E2558F9 /* DiskCacheTests.swift */,
+				6433A35C5237951780F71007CDD7CAF6 /* ExpireTests.swift */,
+				1DA66BD11DFE1B44AEE8B3E87FE69247 /* ForwardRequestOperatorTests.swift */,
+				6EEABCAB89B88547BEBA17DF0A3C9CC5 /* MapTests.swift */,
+				A2ACB9B1E7C386D1C65F90BD7539B766 /* RamCacheTests.swift */,
+				4847C65728065B2E0B3B10E56917CA2F /* RetainTests.swift */,
+				00EEE48D4847E059CB4847D288F402F7 /* ReuseInFlightTests.swift */,
+				6D9FFCE7290B3DF322078B4968D8437A /* SalientTests.swift */,
+				0D968CBD8F99AB066F734268201544D7 /* SkipWhileTests.swift */,
+				350347333DA3AAD73E912D8327670F65 /* SwitchTests.swift */,
 			);
-			name = Tests;
 			path = Tests;
 			sourceTree = "<group>";
 		};
@@ -1409,23 +1406,6 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
-		1A31FF56A86638D72C2BDA6E9BFE8236 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				35E3FA5431060710A7FECBE30D97763D /* CurrentTestCaseTracker.h in Headers */,
-				9B82931CAF7DC34D81B207DF2A30E160 /* CwlCatchException.h in Headers */,
-				E2B9515C01F752D52C0C73E004E6A0F0 /* CwlMachBadInstructionHandler.h in Headers */,
-				0338B975146864D901AA5E770DE5FD12 /* CwlPreconditionTesting.h in Headers */,
-				0D223A33663A0C7B8E9389D375AD8613 /* DSL.h in Headers */,
-				E7F0FF8B1D94AB9A664B0DCED67B1189 /* mach_excServer.h in Headers */,
-				6FACBE27BD32B91E914476ECBEF3BC9C /* Nimble-umbrella.h in Headers */,
-				17D7DE0B2CCB42E91FA9F5A814627E4E /* Nimble.h in Headers */,
-				B5B2E421BCB6D195CE3F2C03DC8E4FB9 /* NMBExceptionCapture.h in Headers */,
-				A19D89D3683E4368230D52014DC2D77A /* NMBStringify.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		1D34EA1D1D4A62B517EFF452B1460325 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -1434,26 +1414,43 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		76F3B986B6E4839F3443621DC53B0C23 /* Headers */ = {
+		3BF4E7B3D254109EAA6A9AD42BE07F4D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				DBA334B9C35E5354E5E81B790C836BC6 /* QCKDSL.h in Headers */,
-				6F2AECB6C7DFFE5CBE8183B0AE0FFB28 /* Quick-umbrella.h in Headers */,
-				05ADC41A172933377F6606E2E513AC6E /* Quick.h in Headers */,
-				374DBC00BF9FEDD8B49906A0B58047F4 /* QuickConfiguration.h in Headers */,
-				D0676BDA3BCB33B0C778AC93180963A5 /* QuickSpec.h in Headers */,
-				F02213CBB1768C8EFB1FFAFCB606C163 /* QuickSpecBase.h in Headers */,
-				7DC290E3B2877F32EC1B0AC16D16A4C7 /* World+DSL.h in Headers */,
-				CFA899A6977D2252AE6B33761B0EE0B7 /* World.h in Headers */,
+				CBABD90934812B50C2F261D11EE2566A /* RxTest-umbrella.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		8B0E142A4E697FD4FE4015A80A1B46D7 /* Headers */ = {
+		5E989EAAC512E76E21DF98F98B6DC083 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				08EDDF54E6AAF16AEA5D116786EB9D70 /* RxTest-umbrella.h in Headers */,
+				FA3656E16AE1779E1B1CF65F4691FB54 /* CurrentTestCaseTracker.h in Headers */,
+				407FFF7FB7CA8918878DBF85E500161F /* CwlCatchException.h in Headers */,
+				9D5F46678C5A4F7A92F6A656D49A1375 /* CwlMachBadInstructionHandler.h in Headers */,
+				E24DFF99625B4F55D281C66A0C0A98F8 /* CwlPreconditionTesting.h in Headers */,
+				B8399AE8B9E042325C5811DE04010F8C /* DSL.h in Headers */,
+				155D1F1399F0B4991583B041BEF0C9CA /* mach_excServer.h in Headers */,
+				5190B51F924F8AD52E26E8DE90313375 /* Nimble-umbrella.h in Headers */,
+				1E6A3CAAD29C874F988D4FF14C18D5C2 /* Nimble.h in Headers */,
+				9601A8CE0C80EBC0ABABFA39194EFE0A /* NMBExceptionCapture.h in Headers */,
+				7028F2E784641F4B5DF87FD5EFD78932 /* NMBStringify.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		731719FF8C6E5009978439E5E11E2BA9 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				100040029E359770EB8AC8F8D9D28B7D /* QCKDSL.h in Headers */,
+				7472792FC36E7A0BBDDD4941632FBDA2 /* Quick-umbrella.h in Headers */,
+				C0FB155C937E91344D74B564681F59AA /* Quick.h in Headers */,
+				C899F3FE4F590583DA7830E9877A349F /* QuickConfiguration.h in Headers */,
+				B6B8C5DF02CDEBEED5B6CF226F9C1ADA /* QuickSpec.h in Headers */,
+				FE54A3934661DF3D8068AD6283DEC6DE /* QuickSpecBase.h in Headers */,
+				98A5B83D0FCB4A3D85BCEBF0A86EE615 /* World+DSL.h in Headers */,
+				E22691B24ADA0C2D815BDC01DD363468 /* World.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1478,46 +1475,6 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
-		20FA9B910D332A1809C9C2C423887904 /* Nimble */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 39C57F59EF4E3536C4353155D219DB70 /* Build configuration list for PBXNativeTarget "Nimble" */;
-			buildPhases = (
-				50A26A27945F3B5461D37C898704E3E8 /* Sources */,
-				3FF48FCE927D8B3D2C6F65490F1C4906 /* Frameworks */,
-				1A31FF56A86638D72C2BDA6E9BFE8236 /* Headers */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = Nimble;
-			productName = Nimble;
-			productReference = 6FE326DFA47E41B7CD91300BAA54C629 /* Nimble.framework */;
-			productType = "com.apple.product-type.framework";
-		};
-		5A81B967EC67244952442AB181DE8E19 /* Droste-Unit-Tests */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 76CB9EF5DDAFFFC51297616036946164 /* Build configuration list for PBXNativeTarget "Droste-Unit-Tests" */;
-			buildPhases = (
-				3BE32DED14731A57B299A211533DE6FB /* Sources */,
-				9F1BC7D19013905316702D04EB65A60B /* Frameworks */,
-				A210FFB7F43AEA66C7313AD0C8C3652F /* [CP] Embed Pods Frameworks */,
-				2C320024C12528EDBFE6F07AF5292239 /* [CP] Copy Pods Resources */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-				773F8EE2C292C6BFDC805624D069A284 /* PBXTargetDependency */,
-				7F1F39AF5D7D4BFB59D71E95A9170D3D /* PBXTargetDependency */,
-				3E18BC209CACFE2830CD1BE609703C20 /* PBXTargetDependency */,
-				49E86D003ACE3A2C2B7058CA75A972AD /* PBXTargetDependency */,
-				FF3ECBA50DA84AFD3BD2709BC69621C1 /* PBXTargetDependency */,
-			);
-			name = "Droste-Unit-Tests";
-			productName = "Droste-Unit-Tests";
-			productReference = F17F7E7A63184E5A88028E15CD2EAC1A /* Droste-Unit-Tests */;
-			productType = "com.apple.product-type.bundle.unit-test";
-		};
 		6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 316AD90DA728FE2E1EDD8B726E24DFD0 /* Build configuration list for PBXNativeTarget "Droste" */;
@@ -1572,31 +1529,30 @@
 			productReference = D09CF1FB612765620BB414D3ED0056D4 /* RxSwift.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		9B3375A14D46317B1F3AE269C44D7F8A /* RxTest */ = {
+		8B1C22EC32AE73C02516415C0152B402 /* Nimble */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = C661C79598CBA606F3BF20C39A459BD7 /* Build configuration list for PBXNativeTarget "RxTest" */;
+			buildConfigurationList = 514DB91EDBB434C87D2079CBFBA4CFE7 /* Build configuration list for PBXNativeTarget "Nimble" */;
 			buildPhases = (
-				701943C5987CFFFB61591592D28FA7EF /* Sources */,
-				201DE67D5B046ECB820E5F6F8B1B1399 /* Frameworks */,
-				8B0E142A4E697FD4FE4015A80A1B46D7 /* Headers */,
+				AD722460CFF46C5FFF4F8E82823133E3 /* Sources */,
+				5A7B9F9B8BDDEDE6FC4008E8FC472478 /* Frameworks */,
+				5E989EAAC512E76E21DF98F98B6DC083 /* Headers */,
 			);
 			buildRules = (
 			);
 			dependencies = (
-				5CE6306BDD69F1369136290311BAFDFF /* PBXTargetDependency */,
 			);
-			name = RxTest;
-			productName = RxTest;
-			productReference = 7D68E41227D7A34AF26E48499DEA8D54 /* RxTest.framework */;
+			name = Nimble;
+			productName = Nimble;
+			productReference = 6FE326DFA47E41B7CD91300BAA54C629 /* Nimble.framework */;
 			productType = "com.apple.product-type.framework";
 		};
-		A7635A015B61D26AF6E4B111CB69BDEF /* Quick */ = {
+		8F6606D3EDE18A70E10FDC3AB59AC49A /* Quick */ = {
 			isa = PBXNativeTarget;
-			buildConfigurationList = 9917E33A047ACB877A6604243E57D8E4 /* Build configuration list for PBXNativeTarget "Quick" */;
+			buildConfigurationList = 538E15BFC3EB42E6BCB82DFD164347FB /* Build configuration list for PBXNativeTarget "Quick" */;
 			buildPhases = (
-				135816BDBD5DB2753BA962A3D1DE62FD /* Sources */,
-				F7410D6EAF182222F51B4A756C0E721D /* Frameworks */,
-				76F3B986B6E4839F3443621DC53B0C23 /* Headers */,
+				BFFE91F3ABB0706B5785BED973377465 /* Sources */,
+				CCF37D35FDF14353A1DAA792F81B91E1 /* Frameworks */,
+				731719FF8C6E5009978439E5E11E2BA9 /* Headers */,
 			);
 			buildRules = (
 			);
@@ -1605,6 +1561,47 @@
 			name = Quick;
 			productName = Quick;
 			productReference = 1A82A5891550F89601465A5DE5BB7434 /* Quick.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		98090E842CFA34D56FD449F79DEC3384 /* Droste-Unit-Tests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 5226CE1AB81BBFAA03D13C6A0D864702 /* Build configuration list for PBXNativeTarget "Droste-Unit-Tests" */;
+			buildPhases = (
+				4BBBB1D17F82F54AC2A64656A367B639 /* Sources */,
+				6C9191EF7770F6CD54361D1A85AABDB5 /* Frameworks */,
+				B382788A64645F9EE74EECAB4D0DB74B /* [CP] Embed Pods Frameworks */,
+				B3034B596F31675C82C0B23FFCD5431D /* [CP] Copy Pods Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				620E23D2C6DD7126AD060F57013D26DE /* PBXTargetDependency */,
+				1E411DBE42A0D85109C2097B47BB187E /* PBXTargetDependency */,
+				EA1B2136A8C965BFC2871234794F6D41 /* PBXTargetDependency */,
+				DEABA2AA063C249DFB6C86ED40519D60 /* PBXTargetDependency */,
+				3FA31C914955CC3A336B97982DC272E9 /* PBXTargetDependency */,
+			);
+			name = "Droste-Unit-Tests";
+			productName = "Droste-Unit-Tests";
+			productReference = F17F7E7A63184E5A88028E15CD2EAC1A /* Droste-Unit-Tests */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
+		A03BA510876E6D21D3EF9757315DC91C /* RxTest */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 05118B691FFAD77BE5C5D1080E10DF1D /* Build configuration list for PBXNativeTarget "RxTest" */;
+			buildPhases = (
+				7E3E27A7C8F5BCD8EEDB5D3D2B7BA7AC /* Sources */,
+				CCA6D21BC0A0E6C93A153437894B1DEF /* Frameworks */,
+				3BF4E7B3D254109EAA6A9AD42BE07F4D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				D856F9694671A4D64FE9B2D7C96D8EE4 /* PBXTargetDependency */,
+			);
+			name = RxTest;
+			productName = RxTest;
+			productReference = 7D68E41227D7A34AF26E48499DEA8D54 /* RxTest.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 /* End PBXNativeTarget section */
@@ -1629,18 +1626,18 @@
 			projectRoot = "";
 			targets = (
 				6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */,
-				5A81B967EC67244952442AB181DE8E19 /* Droste-Unit-Tests */,
-				20FA9B910D332A1809C9C2C423887904 /* Nimble */,
+				98090E842CFA34D56FD449F79DEC3384 /* Droste-Unit-Tests */,
+				8B1C22EC32AE73C02516415C0152B402 /* Nimble */,
 				6F8992968BD73DAA9694DFC7C277FDC0 /* Pods-Example */,
-				A7635A015B61D26AF6E4B111CB69BDEF /* Quick */,
+				8F6606D3EDE18A70E10FDC3AB59AC49A /* Quick */,
 				70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */,
-				9B3375A14D46317B1F3AE269C44D7F8A /* RxTest */,
+				A03BA510876E6D21D3EF9757315DC91C /* RxTest */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXShellScriptBuildPhase section */
-		2C320024C12528EDBFE6F07AF5292239 /* [CP] Copy Pods Resources */ = {
+		B3034B596F31675C82C0B23FFCD5431D /* [CP] Copy Pods Resources */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1655,7 +1652,7 @@
 			shellScript = "\"${PODS_ROOT}/Target Support Files/Droste/Droste-Unit-Tests-resources.sh\"\n";
 			showEnvVarsInLog = 0;
 		};
-		A210FFB7F43AEA66C7313AD0C8C3652F /* [CP] Embed Pods Frameworks */ = {
+		B382788A64645F9EE74EECAB4D0DB74B /* [CP] Embed Pods Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -1684,55 +1681,23 @@
 /* End PBXShellScriptBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
-		135816BDBD5DB2753BA962A3D1DE62FD /* Sources */ = {
+		4BBBB1D17F82F54AC2A64656A367B639 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				10F5D42D18FA365F6D5C3D201485CF16 /* Behavior.swift in Sources */,
-				CC8E9462D1FAEECEA04E0716A18B1A50 /* Callsite.swift in Sources */,
-				FECE46344B0F8264B338456378E0F027 /* Closures.swift in Sources */,
-				A79E72FE105B16E7C6A6FBC79D7D0E7D /* Configuration.swift in Sources */,
-				62BD2DC0DE27B3CC5547033587D7F4E2 /* DSL.swift in Sources */,
-				71B0F56FCA8DDD413B15FA01D9EFC251 /* ErrorUtility.swift in Sources */,
-				332F326CC09BFB2893BB6F8BB34F6A8E /* Example.swift in Sources */,
-				715DE0702F64C0CE5D086F93BF303CED /* ExampleGroup.swift in Sources */,
-				1F66D9DC2277C1493303E986C77D2152 /* ExampleHooks.swift in Sources */,
-				37B9F41B358AAFFC676590924B0E191B /* ExampleMetadata.swift in Sources */,
-				B554A2742210AD6F85A6A0736D76093B /* Filter.swift in Sources */,
-				C09336ACB4D11C3629F19E1B4681281B /* HooksPhase.swift in Sources */,
-				6938331AF11B34267092E3295B450621 /* NSBundle+CurrentTestBundle.swift in Sources */,
-				A620F798081291E0BF981FACCA5C701A /* NSString+C99ExtendedIdentifier.swift in Sources */,
-				FF9A344AF4EE62A205C4BD199AAEA5C1 /* QCKDSL.m in Sources */,
-				EF78F2E60D13696826206C4079ED238E /* Quick-dummy.m in Sources */,
-				A18D1604A0B3A836C1EE6530A3440EFB /* QuickConfiguration.m in Sources */,
-				4D472FBA13EE73EB46A7740DEC941A60 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
-				F8632FF906031D3939B941F6F6D7B00C /* QuickSpec.m in Sources */,
-				57A9D441866697C17FBAF6137D9F03FC /* QuickSpecBase.m in Sources */,
-				3F131EB45A58205368E66823F52EC878 /* QuickTestSuite.swift in Sources */,
-				08EF70BB8DA11248DE6AB0D30C443BCA /* SuiteHooks.swift in Sources */,
-				61BA2BD935A823290AB8F7A856AAD5F1 /* URL+FileName.swift in Sources */,
-				9CEC63C8A312477703953FA38D4DCF46 /* World+DSL.swift in Sources */,
-				A917918EFE191842B5EE36EF3394AD74 /* World.swift in Sources */,
-				C2887A332D9BD897477B72B0238D65D2 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		3BE32DED14731A57B299A211533DE6FB /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				6C3C2F7CE2F2D9E88AE09D5FCFA5A0B9 /* CacheFake.swift in Sources */,
-				C12F0FB7402DE4A2770978C5BB4C6850 /* CompositionTests.swift in Sources */,
-				D58A2C27F18C5386AC39A340968E0C0B /* DiskCacheTests.swift in Sources */,
-				B367074DB2213FAA1691102597FF7EC6 /* Extensions.swift in Sources */,
-				5FE08B18FBF244AA9BB56F0CB350CFCC /* ForwardRequestOperatorTests.swift in Sources */,
-				364515488BACFF39184BA19D0D51715A /* MapTests.swift in Sources */,
-				B9E4929B50A4BAD5701FB9542002525E /* RamCacheTests.swift in Sources */,
-				213FC97651D608E8761A2FB58479ADC3 /* RetainTests.swift in Sources */,
-				D5CC02225146A5DEF9E2B6DB3CA8941E /* ReuseInFlightTests.swift in Sources */,
-				3E5F7F47A7092E1944CF1CD29EFD51F5 /* SalientTests.swift in Sources */,
-				ADBE46FFD944AE1D82BA9B45427182EF /* SkipWhileTests.swift in Sources */,
-				D1E2FA965DB95066E3ECC9F2D90B2773 /* SwitchTests.swift in Sources */,
+				72EB92E7B93CADA1070FEA0B86F493B8 /* CacheFake.swift in Sources */,
+				BFE8C09D04E45686008F06A90985941F /* CompositionTests.swift in Sources */,
+				403E5A276EBCADBC9617B535B1C2B17F /* DiskCacheTests.swift in Sources */,
+				34E8D8FAC5D3AADC86C85354C1315E7E /* ExpireTests.swift in Sources */,
+				665C69BF167AB9818CAC3DDC938C0AD9 /* Extensions.swift in Sources */,
+				22BEBE8D12A13ABDA7961E91631DB89B /* ForwardRequestOperatorTests.swift in Sources */,
+				69DACF7910975210BA9897B4E0080974 /* MapTests.swift in Sources */,
+				1BD39EE039F926A0B74547141BF598A7 /* RamCacheTests.swift in Sources */,
+				8AA53B8407F6A08C6E4C99BD764EB1AD /* RetainTests.swift in Sources */,
+				F49E24601477C82BE742A9321947D1DB /* ReuseInFlightTests.swift in Sources */,
+				FDA273564310BAEE61B963CDDA48E517 /* SalientTests.swift in Sources */,
+				40169289DF2BC00F8B82EA06790181A8 /* SkipWhileTests.swift in Sources */,
+				3A83142C8B4E0192E195304A5CEB9D17 /* SwitchTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1741,103 +1706,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				354033E6429C35730A350582C22A65AB /* Pods-Example-dummy.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		50A26A27945F3B5461D37C898704E3E8 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				5CF8106293869D3A64AAF22EE090B035 /* AdapterProtocols.swift in Sources */,
-				EB393AE3D576DA534054C79DE95735B8 /* AllPass.swift in Sources */,
-				51B119C5686545183621B7B51516BB3A /* AssertionDispatcher.swift in Sources */,
-				DAE19DAC20BD3B93A30F5F4BDF61D622 /* AssertionRecorder.swift in Sources */,
-				0822659E8C3D41902B196E44C8AA9DC0 /* Async.swift in Sources */,
-				B6B8C4D3AC2DECB5235003BAFE605603 /* AsyncMatcherWrapper.swift in Sources */,
-				5E33EEB7ABFA2760656B87D8B6E72819 /* BeAKindOf.swift in Sources */,
-				34FF11A9E918D299FC5C448C132C8881 /* BeAnInstanceOf.swift in Sources */,
-				0CAD7AAF511C7091B684129E05F8E390 /* BeCloseTo.swift in Sources */,
-				EB8ECAEB27B4A2EC19B3BB18EA6AD193 /* BeEmpty.swift in Sources */,
-				BBBECC463322F65D4D03D6295D1BC5CE /* BeginWith.swift in Sources */,
-				E965A95077F792A9FC7460640BBFEBE4 /* BeGreaterThan.swift in Sources */,
-				C527FF40212046670FD1641E63B0CD29 /* BeGreaterThanOrEqualTo.swift in Sources */,
-				E244EE6DD1CD7B6B24871510C1A33735 /* BeIdenticalTo.swift in Sources */,
-				45A507E8E58BC6414049A9267578D9FB /* BeLessThan.swift in Sources */,
-				F9153BFD39BA965E84128BD2D53349BF /* BeLessThanOrEqual.swift in Sources */,
-				7D3235B869EC4E03C93667C9C163DEB1 /* BeLogical.swift in Sources */,
-				E720CC01C8CA5C0DDB57078682328DAC /* BeNil.swift in Sources */,
-				5C663E6DB2E98D355C1BB362174AF99C /* BeVoid.swift in Sources */,
-				B53CB156734BA4AF716A555B86835701 /* Contain.swift in Sources */,
-				24E0E6E24A1712F5379A2E76B6CE1F88 /* ContainElementSatisfying.swift in Sources */,
-				BB2CFA70A57B42F5EA411A9F26A1DEA8 /* CwlBadInstructionException.swift in Sources */,
-				F7D9BB3DBD269AB01C9A828F8ACBC836 /* CwlCatchBadInstruction.swift in Sources */,
-				92EFBA0D7A20A381C3F4CDB81F098883 /* CwlCatchException.m in Sources */,
-				83262CD39AE9A9BD559A810326CFC2B0 /* CwlCatchException.swift in Sources */,
-				23C7AA4804BAE5923E216C317F3C6774 /* CwlDarwinDefinitions.swift in Sources */,
-				ADB92CFC629B21F098BAEC90D415555E /* CwlMachBadInstructionHandler.m in Sources */,
-				B1EBF61F0F3922F1A7BE4223E9D53703 /* DSL+Wait.swift in Sources */,
-				B0C72020BCE863374F0BC3DB4309A924 /* DSL.m in Sources */,
-				515C61278B15FA564587EF581B9B8655 /* DSL.swift in Sources */,
-				2C8F0DBC6229BEFB4288C1E2ACF9C082 /* EndWith.swift in Sources */,
-				DEE0EB0FDD41001482465830F89E6A9D /* Equal.swift in Sources */,
-				920E53F0080CFED03D09DA32387F0F3C /* Errors.swift in Sources */,
-				5023D249C03A75C6E8B18800A0DDDE0C /* Expectation.swift in Sources */,
-				7E394284D01F55E407892097E309C943 /* ExpectationMessage.swift in Sources */,
-				C1E82F9FF2CD436979970279B888205A /* Expression.swift in Sources */,
-				F2D512FE8E6A962E0630F127AB8A0489 /* FailureMessage.swift in Sources */,
-				A336C23F7C23DC23DF6FDD5F0CECFCC3 /* Functional.swift in Sources */,
-				B4BAF015C8BFE16A986A3EC50C6C015E /* HaveCount.swift in Sources */,
-				9B43BA0E11406E19169A84DE6F1531C4 /* mach_excServer.c in Sources */,
-				2B581E08B43374A783FE338A9CFC96BE /* Match.swift in Sources */,
-				E0BC3784027574E48764B59D168EA9B9 /* MatcherFunc.swift in Sources */,
-				BC990A5DC96C7060B48BC1E95B04443F /* MatcherProtocols.swift in Sources */,
-				F58C2663738975CE7FFE8C757F6D6296 /* MatchError.swift in Sources */,
-				CA882FE5A3E6F480BD18DD67D966F3C1 /* Nimble-dummy.m in Sources */,
-				6329C05469EDF9F7AF31A51F04DF1680 /* NimbleEnvironment.swift in Sources */,
-				BA1FAC97337A997DDBDE9AEF2AEA7A75 /* NimbleXCTestHandler.swift in Sources */,
-				36A2373F2EB063A0FFE26862A7DF2367 /* NMBExceptionCapture.m in Sources */,
-				D48BF578ECC0043772B4E83CF8D27DB7 /* NMBExpectation.swift in Sources */,
-				51C649D1B46B04259DFCB5A40FA23008 /* NMBObjCMatcher.swift in Sources */,
-				267C95483B8179811B8A0DD88D5BEDD9 /* NMBStringify.m in Sources */,
-				02533B9F7F4CE9CD179E1F1E0E774F8A /* PostNotification.swift in Sources */,
-				B00EFAD11F1688A53D238E159B927B0B /* Predicate.swift in Sources */,
-				CF14CEE4CE4FB9E86123214E940DE63A /* RaisesException.swift in Sources */,
-				7233C02A9E2357048270B76C12F53CB2 /* SatisfyAnyOf.swift in Sources */,
-				4C5BB237628BDD6B0FB3143E58CB0FF4 /* SourceLocation.swift in Sources */,
-				4E43B22EB39D579A360E8AB2EB54EC1F /* Stringers.swift in Sources */,
-				923A2A207D32196A384A162E6A39C7C0 /* ThrowAssertion.swift in Sources */,
-				CC12FFD5BAD0834C3974E340673BD861 /* ThrowError.swift in Sources */,
-				A4BC6C72C51E19148125E207BE9A8369 /* ToSucceed.swift in Sources */,
-				4597E5BF849E6709638CCCCA28D51F4E /* XCTestObservationCenter+Register.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		701943C5987CFFFB61591592D28FA7EF /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				602229A466EA9CC6CF6EBB292FA92817 /* Any+Equatable.swift in Sources */,
-				B80B26512BDC6877614B7261B16C27A9 /* Bag.swift in Sources */,
-				7D71695D29F3E73697770D4EEAFCDFE8 /* ColdObservable.swift in Sources */,
-				DA4F9EB339859168966BD00BC30981E0 /* Deprecated.swift in Sources */,
-				CAED3B4F1864F2283C0B956968F84089 /* DispatchQueue+Extensions.swift in Sources */,
-				7FEEB9A55BB971E787C4F5253979EE61 /* Event+Equatable.swift in Sources */,
-				2DD307F1CD8D3C1143C764EF397C641A /* HotObservable.swift in Sources */,
-				85D264B5009002B7A79971C8413C870E /* InfiniteSequence.swift in Sources */,
-				A635C44A2419A9684A22993B4052CAD6 /* Platform.Darwin.swift in Sources */,
-				42A447EDEA9D4513DC3C329D3635F305 /* Platform.Linux.swift in Sources */,
-				037248D2F976E6C7AC3AC472274033CD /* PriorityQueue.swift in Sources */,
-				15B10C41A64E1F8A43A6D2826A55EF37 /* Queue.swift in Sources */,
-				CE2484C9FC0C3BBA40DEA9E2CA5ED960 /* Recorded.swift in Sources */,
-				1687FAE4E4C13F98300A1598C8E2F021 /* RecursiveLock.swift in Sources */,
-				D3CFC809A9CBE1EF88F4F3337C4B775D /* RxTest-dummy.m in Sources */,
-				7F7B286BF3C99EF4CB2711E8971CD24F /* RxTests.swift in Sources */,
-				C8A09A059FF9EAF51DEC9ADE2BCA6250 /* Subscription.swift in Sources */,
-				A4EC249AB8725E04B8C310D785BFE993 /* TestableObservable.swift in Sources */,
-				34D7852543CAA5550D357F3942F490AC /* TestableObserver.swift in Sources */,
-				5A1B09C912B9630C872E2D30900ED305 /* TestScheduler.swift in Sources */,
-				85255B609E18C5FEC187E4F957DED344 /* TestSchedulerVirtualTimeConverter.swift in Sources */,
-				9A8FEF430D75035EA575F460AEC15D11 /* XCTest+Rx.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1997,6 +1865,35 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		7E3E27A7C8F5BCD8EEDB5D3D2B7BA7AC /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				5E19B9FEF3A1078504C437EC6258C3B2 /* Any+Equatable.swift in Sources */,
+				0F8ED804E38975CF7427076D67F25148 /* Bag.swift in Sources */,
+				F62783867EB6EBA359F4684D5FA129C5 /* ColdObservable.swift in Sources */,
+				965F8142A4F0472484E1E5C8BE034447 /* Deprecated.swift in Sources */,
+				07104AAD5CBFCC2D4E0621332C63AF92 /* DispatchQueue+Extensions.swift in Sources */,
+				22DF4863E0D7977723ED68FE95215B13 /* Event+Equatable.swift in Sources */,
+				7084172FE15A62B02531E50AC74BD89B /* HotObservable.swift in Sources */,
+				F184A7BBBAD1D692BC451CE502BFB120 /* InfiniteSequence.swift in Sources */,
+				DF6EF09153BD06DEF7B5961BE7EEE973 /* Platform.Darwin.swift in Sources */,
+				7C4A6B872D68CBF09646F0ED641C7FE3 /* Platform.Linux.swift in Sources */,
+				F29B57BBC091455C916265CC763DA758 /* PriorityQueue.swift in Sources */,
+				2F8B8E3412F1417ED63AE6537D309EA8 /* Queue.swift in Sources */,
+				D5250A5EC4E62D98C98F39BE3879A459 /* Recorded.swift in Sources */,
+				84D4D494211E8CE4734CF497E97E9E50 /* RecursiveLock.swift in Sources */,
+				7F7CD3F520043289B2466AE08F56BF1E /* RxTest-dummy.m in Sources */,
+				2F0C096D44EB16CFC5C096180E141680 /* RxTests.swift in Sources */,
+				9F808FF20A668602DEAFB7580B752FAD /* Subscription.swift in Sources */,
+				CF69A10E7589A79739C42311743426FB /* TestableObservable.swift in Sources */,
+				E681DCE69FACEB7060056E09BDA8F3FD /* TestableObserver.swift in Sources */,
+				DBE50B01C01F2D3FAB82D54F1839D3BE /* TestScheduler.swift in Sources */,
+				6D8B10BB6D916241AEC69BE37058258F /* TestSchedulerVirtualTimeConverter.swift in Sources */,
+				6B89CFAFD61D9C3C9976C0BA383A8A97 /* XCTest+Rx.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		A33DE76A825484272493B561D8D6E68C /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -2024,6 +1921,107 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		AD722460CFF46C5FFF4F8E82823133E3 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				286B5E36914A9F2061957A13237F73C0 /* AdapterProtocols.swift in Sources */,
+				34C700F822FC761AD16BC133743C68DA /* AllPass.swift in Sources */,
+				6B72424DAB576D1A36F3D377E1588C07 /* AssertionDispatcher.swift in Sources */,
+				DA1E4B7C3F3DB30397DF51DF436637E2 /* AssertionRecorder.swift in Sources */,
+				7FCC470102CC8131FED8CDB7EEE2D050 /* Async.swift in Sources */,
+				1F19FAB2B06C8A7BABE0201C6C2126E8 /* AsyncMatcherWrapper.swift in Sources */,
+				CEC1A867FA11B37AE0A7E45FAD04AA43 /* BeAKindOf.swift in Sources */,
+				E632A03015466359CB70AAE352527805 /* BeAnInstanceOf.swift in Sources */,
+				715ABC8247032BC59858306F0863F757 /* BeCloseTo.swift in Sources */,
+				E1C46E6FAF7BF8D4501F8424293DD834 /* BeEmpty.swift in Sources */,
+				9B9E9F382B2E314BBA1AA468E656A113 /* BeginWith.swift in Sources */,
+				D5C20373469F194ACFAB5785A1AF231C /* BeGreaterThan.swift in Sources */,
+				9A471840E1C9822AEC8B16286E648901 /* BeGreaterThanOrEqualTo.swift in Sources */,
+				4FC1416F7D01F0A436D1227F8F9255D0 /* BeIdenticalTo.swift in Sources */,
+				A8C2D601AD691613F2EF1DC66DAF9468 /* BeLessThan.swift in Sources */,
+				8CC0E034F66B6DF3C809ED90A9627A6E /* BeLessThanOrEqual.swift in Sources */,
+				CAD86463B4A70A207144C5118F655808 /* BeLogical.swift in Sources */,
+				56AB742771942AE81290855FB0996174 /* BeNil.swift in Sources */,
+				E098C31348AB780FEE7DDEC5651DDC2C /* BeVoid.swift in Sources */,
+				7A9902FD148183A1987F0264C57F36EF /* Contain.swift in Sources */,
+				4D646CBF416302DB9A2A6A2509BBED66 /* ContainElementSatisfying.swift in Sources */,
+				EE43FF4CECE1001483748FE3FF80D410 /* CwlBadInstructionException.swift in Sources */,
+				F8D4195E99AE607828D5CDBF3B88C0E8 /* CwlCatchBadInstruction.swift in Sources */,
+				90D2D84A537BC0D61BA74660FD617572 /* CwlCatchException.m in Sources */,
+				DF791F01AC3B0727A9D1FC3B8232B637 /* CwlCatchException.swift in Sources */,
+				670B083E1504146B3E2A30272B18D861 /* CwlDarwinDefinitions.swift in Sources */,
+				E4C9E089C63F6E75F3285F937AABBD3A /* CwlMachBadInstructionHandler.m in Sources */,
+				8419A6E5B0BFFA00D90502674F2C9D52 /* DSL+Wait.swift in Sources */,
+				9B56FFEF00CEEECEE9CFB893913D3B97 /* DSL.m in Sources */,
+				417119A72C1A2864BCA69C711F6B550B /* DSL.swift in Sources */,
+				722F71331605250E7B859AD9ADB7D509 /* EndWith.swift in Sources */,
+				4726DC318DFF420715F28B907136D3F5 /* Equal.swift in Sources */,
+				2A58E9A888BDB7D89E8B6616A38E49BE /* Errors.swift in Sources */,
+				0433975FF172B8637364A40721435D62 /* Expectation.swift in Sources */,
+				C7E98561C51ADBC90C794A41B3D7D9DC /* ExpectationMessage.swift in Sources */,
+				F0A67405FE63AF28FCED2F0297D07164 /* Expression.swift in Sources */,
+				B1F1F5352BEC3C86A4FAE68ADD6CBBB9 /* FailureMessage.swift in Sources */,
+				2C1920FE333EF913B24327D034C9302C /* Functional.swift in Sources */,
+				C927F2E0DDDE5F68D980E282A76BF60B /* HaveCount.swift in Sources */,
+				3FCB2579409B473B309D3E2FAE7FC839 /* mach_excServer.c in Sources */,
+				C72069155B3EF931B30201994DD05EE1 /* Match.swift in Sources */,
+				1A5484C69EE89B6F67B8B8CDE2031D83 /* MatcherFunc.swift in Sources */,
+				6180C47F2B0EB475803F1534F1421DCA /* MatcherProtocols.swift in Sources */,
+				47827C14E719AE98A4BFA54B51504F05 /* MatchError.swift in Sources */,
+				0035E7B37533996D0B9ECB31FD85D03D /* Nimble-dummy.m in Sources */,
+				49ED66912320BA9BC54420B42D175D9A /* NimbleEnvironment.swift in Sources */,
+				187EC0620251090769818DB7E19C0051 /* NimbleXCTestHandler.swift in Sources */,
+				9FB15E160ECB83E7F1628ED882BDC001 /* NMBExceptionCapture.m in Sources */,
+				CD1C082E29EE239F066589D552C24F28 /* NMBExpectation.swift in Sources */,
+				A00DF3D28294DC105D232BDFB555BD1C /* NMBObjCMatcher.swift in Sources */,
+				FEAF61813D3AFA3C6AE2CE60F164E83B /* NMBStringify.m in Sources */,
+				E20731EF3C9E63E600A6543FF010798C /* PostNotification.swift in Sources */,
+				6EBB9405C47705B0A44AD6ABCC426982 /* Predicate.swift in Sources */,
+				30E158B927813D8E19ECF751BBD3A200 /* RaisesException.swift in Sources */,
+				985712939F4C71581F37E82F0942DB5B /* SatisfyAnyOf.swift in Sources */,
+				FADADB00739B1964CAF0630ED5F0F354 /* SourceLocation.swift in Sources */,
+				6003555E09F7F27869B172832826CE35 /* Stringers.swift in Sources */,
+				92F6EBE1E3056184EBF35ECC37C332F0 /* ThrowAssertion.swift in Sources */,
+				F38DDC9F5FDFD26002229FD69C6C184C /* ThrowError.swift in Sources */,
+				75659A8E5A24F634C04DF77945CD4589 /* ToSucceed.swift in Sources */,
+				83508471FA7071F046963012E421E604 /* XCTestObservationCenter+Register.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		BFFE91F3ABB0706B5785BED973377465 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				0327ADB8AE217772070D0E7334DD363E /* Behavior.swift in Sources */,
+				A6965EEDB02B6D5CC2AAF36B401E48D4 /* Callsite.swift in Sources */,
+				5C66BF3A9B35D2257EF745DFE37BF209 /* Closures.swift in Sources */,
+				034781968A6DA6AD8EDC118B7AFC6CB9 /* Configuration.swift in Sources */,
+				0BCF52716C57DC50BF353DE57A7B9538 /* DSL.swift in Sources */,
+				00266801C94BA359D35188E0D9E8A1F9 /* ErrorUtility.swift in Sources */,
+				FFA2BE12AD975CF3F83BB9CD059C7925 /* Example.swift in Sources */,
+				41C0706128DFD0BB660A262FBFE86401 /* ExampleGroup.swift in Sources */,
+				A188195A19BA5B428E1428A5A57A0D70 /* ExampleHooks.swift in Sources */,
+				708E65BFBDA565CBDE17704F6F3F10F9 /* ExampleMetadata.swift in Sources */,
+				2675B73BE9B31F6C3E983EA107D9BC7A /* Filter.swift in Sources */,
+				2C3654FB63E633F8A5C79A9DE55781C2 /* HooksPhase.swift in Sources */,
+				FCBFA50CEF06BD018C47FE7FEE363CAE /* NSBundle+CurrentTestBundle.swift in Sources */,
+				2D6EA5E18070C714792BE43026DD1EE7 /* NSString+C99ExtendedIdentifier.swift in Sources */,
+				C8705CA3C98E596170FDE29F5E8502E6 /* QCKDSL.m in Sources */,
+				95A8A8F25D6CF1A35AB7C4F342EEDBC5 /* Quick-dummy.m in Sources */,
+				DE179C2759B9844D71CEB963606F36F4 /* QuickConfiguration.m in Sources */,
+				9C89191AC13AEBBD62B15334E626AC65 /* QuickSelectedTestSuiteBuilder.swift in Sources */,
+				100523DCE660DF847B7C1AF80F9D3D13 /* QuickSpec.m in Sources */,
+				408C27536AEAF9E424152DEB52A87BC5 /* QuickSpecBase.m in Sources */,
+				C5A66BF9668B90C4769CE8F2D37DBA60 /* QuickTestSuite.swift in Sources */,
+				2B5ED02193CF6426178C33403A3B758F /* SuiteHooks.swift in Sources */,
+				68B167D6C1B22455F2EAA972D832377A /* URL+FileName.swift in Sources */,
+				1C709EE10D8D243ECABF876EA1E08E77 /* World+DSL.swift in Sources */,
+				5EEAB8DED758DC68CE147666CAEFBAAA /* World.swift in Sources */,
+				501A98E45401392A376203775FC884A0 /* XCTestSuite+QuickTestSuiteBuilder.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
@@ -2033,11 +2031,17 @@
 			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
 			targetProxy = E7FAB65AEDCB1EDEF0569E45A618BDA4 /* PBXContainerItemProxy */;
 		};
-		3E18BC209CACFE2830CD1BE609703C20 /* PBXTargetDependency */ = {
+		1E411DBE42A0D85109C2097B47BB187E /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = Quick;
-			target = A7635A015B61D26AF6E4B111CB69BDEF /* Quick */;
-			targetProxy = C0FC7C7F3EB8010BB106CC5937F46C30 /* PBXContainerItemProxy */;
+			name = Nimble;
+			target = 8B1C22EC32AE73C02516415C0152B402 /* Nimble */;
+			targetProxy = AC9001E92A9F33889CC030DFC331FA7A /* PBXContainerItemProxy */;
+		};
+		3FA31C914955CC3A336B97982DC272E9 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RxTest;
+			target = A03BA510876E6D21D3EF9757315DC91C /* RxTest */;
+			targetProxy = A709B61DF98E4E76A32CF13F0912AA89 /* PBXContainerItemProxy */;
 		};
 		49DA055D0E097DBF05812ED3FDF83333 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2045,29 +2049,11 @@
 			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
 			targetProxy = 1699F41ADAEDAAB9AE67F6431482CD89 /* PBXContainerItemProxy */;
 		};
-		49E86D003ACE3A2C2B7058CA75A972AD /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = RxSwift;
-			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
-			targetProxy = 1199D1B5704D35AC623D1239C98E6403 /* PBXContainerItemProxy */;
-		};
-		5CE6306BDD69F1369136290311BAFDFF /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = RxSwift;
-			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
-			targetProxy = C5A4A845EA0C8EE670D1099DF84094C2 /* PBXContainerItemProxy */;
-		};
-		773F8EE2C292C6BFDC805624D069A284 /* PBXTargetDependency */ = {
+		620E23D2C6DD7126AD060F57013D26DE /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			name = Droste;
 			target = 6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */;
-			targetProxy = A78C7A453F63DA606326A64B9E02C72E /* PBXContainerItemProxy */;
-		};
-		7F1F39AF5D7D4BFB59D71E95A9170D3D /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			name = Nimble;
-			target = 20FA9B910D332A1809C9C2C423887904 /* Nimble */;
-			targetProxy = F8F892A517324F6DD774820E501BBA41 /* PBXContainerItemProxy */;
+			targetProxy = 5AC75D0EEC58534ECA6FD275431139DE /* PBXContainerItemProxy */;
 		};
 		899C58F5B2405BA0F41AA30D470DAE80 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -2075,11 +2061,23 @@
 			target = 6BB8A926AFD1D0838DDCF56EF0045469 /* Droste */;
 			targetProxy = 4690A10ADB93BFF49EF15AF09554C1FE /* PBXContainerItemProxy */;
 		};
-		FF3ECBA50DA84AFD3BD2709BC69621C1 /* PBXTargetDependency */ = {
+		D856F9694671A4D64FE9B2D7C96D8EE4 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
-			name = RxTest;
-			target = 9B3375A14D46317B1F3AE269C44D7F8A /* RxTest */;
-			targetProxy = 891D036854C8540C4A334219AFB90811 /* PBXContainerItemProxy */;
+			name = RxSwift;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
+			targetProxy = A39EE34BFA9B53DF40C599F31392A730 /* PBXContainerItemProxy */;
+		};
+		DEABA2AA063C249DFB6C86ED40519D60 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = RxSwift;
+			target = 70678CEEC2D6718B01A9E5A063E2A022 /* RxSwift */;
+			targetProxy = 10DC1DE2985CECE4EA0DBFB688195971 /* PBXContainerItemProxy */;
+		};
+		EA1B2136A8C965BFC2871234794F6D41 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			name = Quick;
+			target = 8F6606D3EDE18A70E10FDC3AB59AC49A /* Quick */;
+			targetProxy = C72A211515F118B4609C0162189C679E /* PBXContainerItemProxy */;
 		};
 /* End PBXTargetDependency section */
 
@@ -2118,9 +2116,9 @@
 			};
 			name = Release;
 		};
-		1E3264E295BF2FFE46711CA036E0A9F1 /* Release */ = {
+		03175B4F5172983EE698F9F359A31791 /* Release */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C7D61CF3A98284AF8463F2016518264 /* RxTest.xcconfig */;
+			baseConfigurationReference = 0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2131,13 +2129,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/RxTest/RxTest-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RxTest/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/RxTest/RxTest.modulemap";
-				PRODUCT_NAME = RxTest;
+				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
+				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2149,6 +2147,57 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
+		};
+		2DA3B408787AAA0E1A99015CD56D8B04 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */;
+			buildSettings = {
+				CODE_SIGNING_REQUIRED = YES;
+				CODE_SIGN_IDENTITY = "iPhone Developer";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-Unit-Tests-prefix.pch";
+				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
+				PRODUCT_NAME = "Droste-Unit-Tests";
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		306695B85534CF7E3919C6916A5BFC03 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				PRODUCT_NAME = Nimble;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
 		};
 		40DA04C3639C75E5CDC789AD2C51084D /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2181,7 +2230,39 @@
 			};
 			name = Debug;
 		};
-		47C66D10ABAF9EBECB930B582FE20E89 /* Debug */ = {
+		4218D8FF79C62487BE3AE812245774FF /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2C7D61CF3A98284AF8463F2016518264 /* RxTest.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RxTest/RxTest-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RxTest/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/RxTest/RxTest.modulemap";
+				PRODUCT_NAME = RxTest;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
+		};
+		45C9C1F410AFBB6F5CCAD69D4CCD5B60 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */;
 			buildSettings = {
@@ -2203,89 +2284,6 @@
 				SWIFT_VERSION = 4.0;
 			};
 			name = Debug;
-		};
-		4C6EF708ECE485EA5751021AEBFB31FD /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
-				PRODUCT_NAME = Nimble;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
-		};
-		4F540F672FED630C4D5E2CED3F0151DE /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
-				PRODUCT_NAME = Nimble;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
-		56F1BFFC0C9686138A434C0E317A0D3F /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 22F923D994EF680229FE3DA59037661B /* Droste.unit.xcconfig */;
-			buildSettings = {
-				CODE_SIGNING_REQUIRED = YES;
-				CODE_SIGN_IDENTITY = "iPhone Developer";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				GCC_PREFIX_HEADER = "Target Support Files/Droste/Droste-Unit-Tests-prefix.pch";
-				IPHONEOS_DEPLOYMENT_TARGET = 9.0;
-				PRODUCT_NAME = "Droste-Unit-Tests";
-				SDKROOT = iphoneos;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				VALIDATE_PRODUCT = YES;
-			};
-			name = Release;
 		};
 		577A74E56041993A1817F1C1E2C12C4B /* Release */ = {
 			isa = XCBuildConfiguration;
@@ -2318,37 +2316,6 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Release;
-		};
-		58873EDE4149E38953869E2FFC3367CF /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
-				PRODUCT_NAME = Quick;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Debug;
 		};
 		7C07ED8089F70A31B83996A8910D7F18 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2410,9 +2377,9 @@
 			};
 			name = Debug;
 		};
-		85097354BF76AA29AF0E4B832F5ECB4D /* Debug */ = {
+		92AB4BA67A361A7540CCD86924DACA15 /* Debug */ = {
 			isa = XCBuildConfiguration;
-			baseConfigurationReference = 2C7D61CF3A98284AF8463F2016518264 /* RxTest.xcconfig */;
+			baseConfigurationReference = 0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */;
 			buildSettings = {
 				CODE_SIGN_IDENTITY = "";
 				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
@@ -2423,13 +2390,13 @@
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/RxTest/RxTest-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/RxTest/Info.plist";
+				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/RxTest/RxTest.modulemap";
-				PRODUCT_NAME = RxTest;
+				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
+				PRODUCT_NAME = Quick;
 				SDKROOT = iphoneos;
 				SKIP_INSTALL = YES;
 				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
@@ -2474,6 +2441,38 @@
 				VERSION_INFO_PREFIX = "";
 			};
 			name = Debug;
+		};
+		95C96E488FE135453864046FB523F600 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = A5D174F7A89C06C0091D7E1C1055F1CC /* Nimble.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/Nimble/Nimble-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/Nimble/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/Nimble/Nimble.modulemap";
+				PRODUCT_NAME = Nimble;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VALIDATE_PRODUCT = YES;
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Release;
 		};
 		9649365587591908AFE80360C08AE176 /* Debug */ = {
 			isa = XCBuildConfiguration;
@@ -2561,6 +2560,37 @@
 			};
 			name = Release;
 		};
+		99A2FB3B57CFB8E8D360445440ECB187 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 2C7D61CF3A98284AF8463F2016518264 /* RxTest.xcconfig */;
+			buildSettings = {
+				CODE_SIGN_IDENTITY = "";
+				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
+				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
+				CURRENT_PROJECT_VERSION = 1;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_PREFIX_HEADER = "Target Support Files/RxTest/RxTest-prefix.pch";
+				INFOPLIST_FILE = "Target Support Files/RxTest/Info.plist";
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				MODULEMAP_FILE = "Target Support Files/RxTest/RxTest.modulemap";
+				PRODUCT_NAME = RxTest;
+				SDKROOT = iphoneos;
+				SKIP_INSTALL = YES;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+				SWIFT_VERSION = 4.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+				VERSIONING_SYSTEM = "apple-generic";
+				VERSION_INFO_PREFIX = "";
+			};
+			name = Debug;
+		};
 		DCA6064882EF4182211202F7559E7ED0 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = C4E1D053B262DFEC143ABA750D058A4B /* Droste.xcconfig */;
@@ -2593,41 +2623,18 @@
 			};
 			name = Release;
 		};
-		F13E60F91EE9E33DA20F6024B0024EF0 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 0A1048EF53B79A379E452938BBB846B9 /* Quick.xcconfig */;
-			buildSettings = {
-				CODE_SIGN_IDENTITY = "";
-				"CODE_SIGN_IDENTITY[sdk=appletvos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
-				"CODE_SIGN_IDENTITY[sdk=watchos*]" = "";
-				CURRENT_PROJECT_VERSION = 1;
-				DEFINES_MODULE = YES;
-				DYLIB_COMPATIBILITY_VERSION = 1;
-				DYLIB_CURRENT_VERSION = 1;
-				DYLIB_INSTALL_NAME_BASE = "@rpath";
-				GCC_PREFIX_HEADER = "Target Support Files/Quick/Quick-prefix.pch";
-				INFOPLIST_FILE = "Target Support Files/Quick/Info.plist";
-				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
-				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
-				MODULEMAP_FILE = "Target Support Files/Quick/Quick.modulemap";
-				PRODUCT_NAME = Quick;
-				SDKROOT = iphoneos;
-				SKIP_INSTALL = YES;
-				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "$(inherited) ";
-				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
-				SWIFT_VERSION = 4.0;
-				TARGETED_DEVICE_FAMILY = "1,2";
-				VALIDATE_PRODUCT = YES;
-				VERSIONING_SYSTEM = "apple-generic";
-				VERSION_INFO_PREFIX = "";
-			};
-			name = Release;
-		};
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		05118B691FFAD77BE5C5D1080E10DF1D /* Build configuration list for PBXNativeTarget "RxTest" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				99A2FB3B57CFB8E8D360445440ECB187 /* Debug */,
+				4218D8FF79C62487BE3AE812245774FF /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		2D8E8EC45A3A1A1D94AE762CB5028504 /* Build configuration list for PBXProject "Pods" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -2646,29 +2653,29 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		39C57F59EF4E3536C4353155D219DB70 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
+		514DB91EDBB434C87D2079CBFBA4CFE7 /* Build configuration list for PBXNativeTarget "Nimble" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				4C6EF708ECE485EA5751021AEBFB31FD /* Debug */,
-				4F540F672FED630C4D5E2CED3F0151DE /* Release */,
+				306695B85534CF7E3919C6916A5BFC03 /* Debug */,
+				95C96E488FE135453864046FB523F600 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		76CB9EF5DDAFFFC51297616036946164 /* Build configuration list for PBXNativeTarget "Droste-Unit-Tests" */ = {
+		5226CE1AB81BBFAA03D13C6A0D864702 /* Build configuration list for PBXNativeTarget "Droste-Unit-Tests" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				47C66D10ABAF9EBECB930B582FE20E89 /* Debug */,
-				56F1BFFC0C9686138A434C0E317A0D3F /* Release */,
+				45C9C1F410AFBB6F5CCAD69D4CCD5B60 /* Debug */,
+				2DA3B408787AAA0E1A99015CD56D8B04 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
-		9917E33A047ACB877A6604243E57D8E4 /* Build configuration list for PBXNativeTarget "Quick" */ = {
+		538E15BFC3EB42E6BCB82DFD164347FB /* Build configuration list for PBXNativeTarget "Quick" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
-				58873EDE4149E38953869E2FFC3367CF /* Debug */,
-				F13E60F91EE9E33DA20F6024B0024EF0 /* Release */,
+				92AB4BA67A361A7540CCD86924DACA15 /* Debug */,
+				03175B4F5172983EE698F9F359A31791 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
@@ -2678,15 +2685,6 @@
 			buildConfigurations = (
 				40DA04C3639C75E5CDC789AD2C51084D /* Debug */,
 				577A74E56041993A1817F1C1E2C12C4B /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		C661C79598CBA606F3BF20C39A459BD7 /* Build configuration list for PBXNativeTarget "RxTest" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				85097354BF76AA29AF0E4B832F5ECB4D /* Debug */,
-				1E3264E295BF2FFE46711CA036E0A9F1 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Example/Pods/Target Support Files/Droste/Info.plist
+++ b/Example/Pods/Target Support Files/Droste/Info.plist
@@ -15,7 +15,7 @@
   <key>CFBundlePackageType</key>
   <string>FMWK</string>
   <key>CFBundleShortVersionString</key>
-  <string>0.1.0</string>
+  <string>0.1.1</string>
   <key>CFBundleSignature</key>
   <string>????</string>
   <key>CFBundleVersion</key>

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ jsonCache
 
 ## Features
 - [x] [Out of the box support for UIImage, JSON, NSData](#out-of-the-box)
+- [x] [Expirable caches](#expirable-caches)
 - [x] [Combine caches easily (e.g. ram + disk + network)](#compose-caches)
 - [x] [Because `.get` returns a `Cancelable` when you subscribe, you can cancel the request anytime](#cancel-requests)
 - [x] [Combine different type of caches by mapping the value of caches using `.mapValues` and the key using `.mapKeys`](#map-values-and-keys)
@@ -106,6 +107,25 @@ let ramDiskCache = ramCache.compose(other: diskCache)
 
 //Same composition example using the the overloaded `+` operator
 let ramDiskCache = ramCache + diskCache
+```
+
+### Expirable caches
+You can set expiry in each cache that supports it. DiskCache and RamCache both have out of the box support!
+You can set an expiry in the following ways
+```swift
+// seconds from now
+let ramCache = RamCache<URL, NSData>().expires(at: .seconds(30))
+
+// or by explicitly setting a date 
+let diskCache = DiskCache<URL, NSData>().expires(at: .date(Date(timeIntervalSince1970: 1516045540)))
+```
+
+Refreshing a resource after 5 minutes in both ram and disk cache.
+```swift
+let ramCache = RamCache<URL, NSData>().expires(at: .seconds(600))
+let diskCache = DiskCache<URL, NSData>().expires(at: .seconds(600))
+
+let dataCache = ramCache + diskCache + networkFetcher
 ```
 
 ### Cancel Requests

--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ github "gtsifrikas/Droste" ~> 0.1.1
 - [ ] Support macOS
 - [ ] Support linux
 - [ ] Update README to include custom Cache creation.
-- [ ] Come up with a api for TTL and support it in DiskCache and RamCache.
+- [x] Come up with a api for TTL and support it in DiskCache and RamCache.
 
 ## Author
 

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -14,9 +14,9 @@ public enum Expiry {
     case date(Foundation.Date)
 }
 
-extension Cache where Value: NSCoding {
+public extension Cache where Value: NSCoding {
     
-    public func expires(expiry: Expiry) -> CompositeCache<Key, Value> {
+    public func expires(at expiry: Expiry) -> CompositeCache<Key, Value> {
         let internalCache = self.mapValues(f: { (newValue: Value) -> CacheExpirableDTO in
             return CacheExpirableDTO(value: newValue, expiryDate: self.date(for: expiry))
         }, fInv: { (cacheDTO: CacheExpirableDTO) -> Value in

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -15,8 +15,8 @@ public enum Expiry {
 }
 
 public protocol ExpirableCache: Cache {
-    func get(_ key: Self.Key) -> Observable<CacheExpirableDTO?>
-    func set(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void>
+    func _getExpirableDTO(_ key: Self.Key) -> Observable<CacheExpirableDTO?>
+    func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void>
 }
 
 public extension Cache where Value: NSCoding, Self: ExpirableCache {
@@ -25,7 +25,7 @@ public extension Cache where Value: NSCoding, Self: ExpirableCache {
         return
             CompositeCache(
                 get: {(key: Key) -> Observable<Value?> in
-                    return self.get(key)
+                    return self._getExpirableDTO(key)
                         .map({ (cacheDTO: CacheExpirableDTO?) -> Value? in
                             //TODO: check the expiry
                             guard let cacheDTO = cacheDTO else { return nil }
@@ -35,7 +35,7 @@ public extension Cache where Value: NSCoding, Self: ExpirableCache {
                 }
                 , set: {(value: Value, key: Key) in
                     let cacheDTO = CacheExpirableDTO(value: value, expiryDate: self.date(for: expiry))
-                    return self.set(cacheDTO, for: key)
+                    return self._setExpirableDTO(cacheDTO, for: key)
                 },
                   clear: clear)
     }

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -15,10 +15,6 @@ public enum Expiry {
 }
 
 public protocol ExpirableCache: Cache {
-    
-    func _getExpirableDTO(_ key: Self.Key) -> Observable<CacheExpirableDTO?>
-    func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void>
-    
     func getData<GenericValueType>(_ key: Self.Key) -> Observable<GenericValueType?>
     func setData<GenericValueType>(_ value: GenericValueType, for key: Self.Key) -> Observable<Void>
 }
@@ -27,16 +23,8 @@ public extension ExpirableCache {
     public func get(_ key: Key) -> Observable<Value?> {
         return getData(key)
     }
-    
-    public func _getExpirableDTO(_ key: Self.Key) -> Observable<CacheExpirableDTO?> {
-        return getData(key)
-    }
-    
+
     public func set(_ value: Value, for key: Key) -> Observable<Void> {
-        return setData(value, for: key)
-    }
-    
-    public func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void> {
         return setData(value, for: key)
     }
 }
@@ -47,7 +35,7 @@ public extension ExpirableCache {
         return
             CompositeCache(
                 get: {(key: Key) -> Observable<Value?> in
-                    return self._getExpirableDTO(key)
+                    return self.getData(key)
                         .map({ (cacheDTO: CacheExpirableDTO?) -> Value? in
                             guard let cacheDTO = cacheDTO else { return nil }
                             guard !cacheDTO.isExpired() else { return nil }
@@ -56,7 +44,7 @@ public extension ExpirableCache {
                 }
                 , set: {(value: Value, key: Key) in
                     let cacheDTO = CacheExpirableDTO(value: value as AnyObject, expiryDate: self.date(for: expiry))
-                    return self._setExpirableDTO(cacheDTO, for: key)
+                    return self.setData(cacheDTO, for: key)
                 },
                   clear: clear)
     }

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -19,7 +19,7 @@ public protocol ExpirableCache: Cache {
     func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void>
 }
 
-public extension Cache where Value: NSCoding, Self: ExpirableCache {
+public extension ExpirableCache {
     
     public func expires(at expiry: Expiry) -> CompositeCache<Key, Value> {
         return
@@ -33,7 +33,7 @@ public extension Cache where Value: NSCoding, Self: ExpirableCache {
                         })
                 }
                 , set: {(value: Value, key: Key) in
-                    let cacheDTO = CacheExpirableDTO(value: value, expiryDate: self.date(for: expiry))
+                    let cacheDTO = CacheExpirableDTO(value: value as AnyObject, expiryDate: self.date(for: expiry))
                     return self._setExpirableDTO(cacheDTO, for: key)
                 },
                   clear: clear)
@@ -61,6 +61,8 @@ public class CacheExpirableDTO: NSObject, NSCoding {
     }
     
     func isExpired() -> Bool {
+        print("Expiry date: \(expiryDate)")
+        print("Dates diff in sec: \(expiryDate.timeIntervalSinceNow)")
         return expiryDate.isInThePast
     }
     

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -9,7 +9,6 @@ import Foundation
 import RxSwift
 
 public enum Expiry {
-    case never
     case seconds(TimeInterval)
     case date(Foundation.Date)
 }
@@ -51,8 +50,6 @@ public extension ExpirableCache {
     
     private func date(for expiry: Expiry) -> Date {
         switch expiry {
-        case .never:
-            return Date.distantFuture
         case .seconds(let seconds):
             return Date().addingTimeInterval(seconds)
         case .date(let date):

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -1,0 +1,87 @@
+//
+//  ExpirableCache.swift
+//  Droste
+//
+//  Created by George Tsifrikas on 04/12/2017.
+//
+
+import Foundation
+import RxSwift
+
+public enum Expiry {
+    case never
+    case seconds(TimeInterval)
+    case date(Foundation.Date)
+}
+
+extension Cache where Value: NSCoding {
+    
+    public func expires(expiry: Expiry) -> CompositeCache<Key, Value> {
+        let internalCache = self.mapValues(f: { (newValue: Value) -> CacheExpirableDTO in
+            return CacheExpirableDTO(value: newValue, expiryDate: self.date(for: expiry))
+        }, fInv: { (cacheDTO: CacheExpirableDTO) -> Value in
+            return cacheDTO.value as! Value
+        })
+        return
+            CompositeCache(
+                get: {(key: Key) -> Observable<Value?> in
+                    return internalCache.get(key).map({ (dto) -> Value? in
+                        return dto?.value as? Value ?? nil
+                    })
+                }
+                , set: {value, key in
+                    let dto = CacheExpirableDTO(value: value, expiryDate: self.date(for: expiry))
+                    return internalCache.set(dto, for: key)
+                },
+          clear: clear)
+    }
+    
+    private func date(for expiry: Expiry) -> Date {
+        switch expiry {
+        case .never:
+            return Date.distantFuture
+        case .seconds(let seconds):
+            return Date().addingTimeInterval(seconds)
+        case .date(let date):
+            return date
+        }
+    }
+}
+
+
+@objc(_TtC6DrosteP33_82153F3EB6261FB7BD1F3A359158A49D17CacheExpirableDTO)
+fileprivate class CacheExpirableDTO: NSObject, NSCoding {
+    let value: AnyObject
+    let expiryDate: Date
+
+    init(value: AnyObject, expiryDate: Date) {
+        self.value = value
+        self.expiryDate = expiryDate
+    }
+    
+    func isExpired() -> Bool {
+        return expiryDate.isInThePast
+    }
+    
+    required init?(coder aDecoder: NSCoder) {
+        guard let val = aDecoder.decodeObject(forKey: "value"),
+            let expiry = aDecoder.decodeObject(forKey: "expiryDate") as? Date else {
+                return nil
+        }
+        
+        self.value = val as AnyObject
+        self.expiryDate = expiry
+        super.init()
+    }
+    
+    func encode(with aCoder: NSCoder) {
+        aCoder.encode(value, forKey: "value")
+        aCoder.encode(expiryDate, forKey: "expiryDate")
+    }
+}
+
+fileprivate extension Date {
+    var isInThePast: Bool {
+        return self.timeIntervalSinceNow < 0
+    }
+}

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -71,8 +71,6 @@ public class CacheExpirableDTO: NSObject, NSCoding {
     }
     
     func isExpired() -> Bool {
-        print("Expiry date: \(expiryDate)")
-        print("Dates diff in sec: \(expiryDate.timeIntervalSinceNow)")
         return expiryDate.isInThePast
     }
     

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -14,17 +14,17 @@ public enum Expiry {
 }
 
 public protocol ExpirableCache: Cache {
-    func getData<GenericValueType>(_ key: Self.Key) -> Observable<GenericValueType?>
-    func setData<GenericValueType>(_ value: GenericValueType, for key: Self.Key) -> Observable<Void>
+    func _getData<GenericValueType>(_ key: Self.Key) -> Observable<GenericValueType?>
+    func _setData<GenericValueType>(_ value: GenericValueType, for key: Self.Key) -> Observable<Void>
 }
 
 public extension ExpirableCache {
     public func get(_ key: Key) -> Observable<Value?> {
-        return getData(key)
+        return _getData(key)
     }
 
     public func set(_ value: Value, for key: Key) -> Observable<Void> {
-        return setData(value, for: key)
+        return _setData(value, for: key)
     }
 }
 
@@ -34,7 +34,7 @@ public extension ExpirableCache {
         return
             CompositeCache(
                 get: {(key: Key) -> Observable<Value?> in
-                    return self.getData(key)
+                    return self._getData(key)
                         .map({ (cacheDTO: CacheExpirableDTO?) -> Value? in
                             guard let cacheDTO = cacheDTO else { return nil }
                             guard !cacheDTO.isExpired() else { return nil }
@@ -43,7 +43,7 @@ public extension ExpirableCache {
                 }
                 , set: {(value: Value, key: Key) in
                     let cacheDTO = CacheExpirableDTO(value: value as AnyObject, expiryDate: self.date(for: expiry))
-                    return self.setData(cacheDTO, for: key)
+                    return self._setData(cacheDTO, for: key)
                 },
                   clear: clear)
     }

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -27,7 +27,6 @@ public extension Cache where Value: NSCoding, Self: ExpirableCache {
                 get: {(key: Key) -> Observable<Value?> in
                     return self._getExpirableDTO(key)
                         .map({ (cacheDTO: CacheExpirableDTO?) -> Value? in
-                            //TODO: check the expiry
                             guard let cacheDTO = cacheDTO else { return nil }
                             guard !cacheDTO.isExpired() else { return nil }
                             return cacheDTO.value as? Value

--- a/Sources/Cache+Expire.swift
+++ b/Sources/Cache+Expire.swift
@@ -15,8 +15,30 @@ public enum Expiry {
 }
 
 public protocol ExpirableCache: Cache {
+    
     func _getExpirableDTO(_ key: Self.Key) -> Observable<CacheExpirableDTO?>
     func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void>
+    
+    func getData<GenericValueType>(_ key: Self.Key) -> Observable<GenericValueType?>
+    func setData<GenericValueType>(_ value: GenericValueType, for key: Self.Key) -> Observable<Void>
+}
+
+public extension ExpirableCache {
+    public func get(_ key: Key) -> Observable<Value?> {
+        return getData(key)
+    }
+    
+    public func _getExpirableDTO(_ key: Self.Key) -> Observable<CacheExpirableDTO?> {
+        return getData(key)
+    }
+    
+    public func set(_ value: Value, for key: Key) -> Observable<Void> {
+        return setData(value, for: key)
+    }
+    
+    public func _setExpirableDTO(_ value: CacheExpirableDTO, for key: Self.Key) -> Observable<Void> {
+        return setData(value, for: key)
+    }
 }
 
 public extension ExpirableCache {

--- a/Sources/Caches.swift
+++ b/Sources/Caches.swift
@@ -14,18 +14,18 @@ public struct DrosteCaches {
     public static var sharedJSONCache = jsonCache()
     public static var sharedImageCache = imageCache()
     
-    public static func dataCache() -> CompositeCache<URL, NSData> {
+    public static func dataCache(expires: Expiry = .never) -> CompositeCache<URL, NSData> {
         let networkFetcher = NetworkFetcher()
             .mapKeys { (url: URL) -> URLRequest in//map url to urlrequest
                 return URLRequest(url: url)
         }
-        let diskCache = DiskCache<URL, NSData>()
-        let ramCache = RamCache<URL, NSData>()
+        let diskCache = DiskCache<URL, NSData>().expires(at: expires)
+        let ramCache = RamCache<URL, NSData>().expires(at: expires)
         return ramCache + (diskCache + networkFetcher).reuseInFlight()
     }
     
-    public static func jsonCache() -> CompositeCache<URL, AnyObject> {
-        return dataCache()
+    public static func jsonCache(expires: Expiry = .never) -> CompositeCache<URL, AnyObject> {
+        return dataCache(expires: expires)
             .mapValues(f: { (data) -> AnyObject in
                 //convert NSData to json object
                 return try JSONSerialization.jsonObject(with: data as Data, options: [.allowFragments]) as AnyObject
@@ -35,8 +35,8 @@ public struct DrosteCaches {
             })
     }
     
-    public static func imageCache() -> CompositeCache<URL, UIImage> {
-        return dataCache()
+    public static func imageCache(expires: Expiry = .never) -> CompositeCache<URL, UIImage> {
+        return dataCache(expires: expires)
             .mapValues(
                 f: { (data) -> UIImage in
                     return UIImage(data: data as Data)!

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -17,7 +17,7 @@ public enum DrosteDiskError: Error {
     case diskSaveFailed
 }
 
-public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, V: NSCoding {
+final public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, V: NSCoding {
     
     public typealias Key = K
     public typealias Value = V
@@ -79,7 +79,7 @@ public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, 
             })
     }
     
-    func getData(_ key: K) -> Observable<AnyObject?> {
+    private func getData(_ key: K) -> Observable<AnyObject?> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
             if let obj = NSKeyedUnarchiver.unarchive(with: path) as? AnyObject {
@@ -105,7 +105,7 @@ public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, 
         return self.setData(value, for: key)
     }
     
-    func setData(_ value: AnyObject, for key: K) -> Observable<Void> {
+    private func setData(_ value: AnyObject, for key: K) -> Observable<Void> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
             let previousSize = self.sizeForFileAtPath(path)

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -67,22 +67,22 @@ final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V
     
     public func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
         return self.getData(key)
-            .map({ (object) -> CacheExpirableDTO? in
-               return object as? CacheExpirableDTO
+            .map({ (object: CacheExpirableDTO?) -> CacheExpirableDTO? in
+               return object
             })
     }
     
     public func get(_ key: K) -> Observable<V?> {
         return self.getData(key)
-            .map({ (object) -> V? in
-                return object as? V
+            .map({ (object: V?) -> V? in
+                return object
             })
     }
     
-    private func getData(_ key: K) -> Observable<AnyObject?> {
+    private func getData<ValueType>(_ key: K) -> Observable<ValueType?> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
-            if let obj = NSKeyedUnarchiver.unarchive(with: path) as? AnyObject {
+            if let obj = NSKeyedUnarchiver.unarchive(with: path) as? ValueType {
                 observer.onNext(obj)
                 observer.onCompleted()
                 _ = self.updateDiskAccessDateAtPath(path)

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -65,7 +65,7 @@ public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, 
         }
     }
     
-    public func get(_ key: K) -> Observable<CacheExpirableDTO?> {
+    public func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
         return self.getData(key)
             .map({ (object) -> CacheExpirableDTO? in
                return object as? CacheExpirableDTO
@@ -97,7 +97,7 @@ public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, 
             .observeOn(MainScheduler.instance)
     }
     
-    public func set(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
+    public func _setExpirableDTO(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
         return self.setData(value, for: key)
     }
     

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -65,7 +65,7 @@ final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V
         }
     }
     
-    public func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+    public func _getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
             if let obj = NSKeyedUnarchiver.unarchive(with: path) as? GenericValueType {
@@ -83,7 +83,7 @@ final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V
             .observeOn(MainScheduler.instance)
     }
 
-    public func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
+    public func _setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
             let previousSize = self.sizeForFileAtPath(path)

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -17,7 +17,7 @@ public enum DrosteDiskError: Error {
     case diskSaveFailed
 }
 
-final public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, V: NSCoding {
+final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V: NSCoding {
     
     public typealias Key = K
     public typealias Value = V

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -65,24 +65,10 @@ final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V
         }
     }
     
-    public func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
-        return self.getData(key)
-            .map({ (object: CacheExpirableDTO?) -> CacheExpirableDTO? in
-               return object
-            })
-    }
-    
-    public func get(_ key: K) -> Observable<V?> {
-        return self.getData(key)
-            .map({ (object: V?) -> V? in
-                return object
-            })
-    }
-    
-    private func getData<ValueType>(_ key: K) -> Observable<ValueType?> {
+    public func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
-            if let obj = NSKeyedUnarchiver.unarchive(with: path) as? ValueType {
+            if let obj = NSKeyedUnarchiver.unarchive(with: path) as? GenericValueType {
                 observer.onNext(obj)
                 observer.onCompleted()
                 _ = self.updateDiskAccessDateAtPath(path)
@@ -96,16 +82,8 @@ final public class DiskCache<K, V>: ExpirableCache where K: StringConvertible, V
             .subscribeOn(cacheScheduler)
             .observeOn(MainScheduler.instance)
     }
-    
-    public func _setExpirableDTO(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
-        return self.setData(value, for: key)
-    }
-    
-    public func set(_ value: V, for key: K) -> Observable<Void> {
-        return self.setData(value, for: key)
-    }
-    
-    private func setData(_ value: AnyObject, for key: K) -> Observable<Void> {
+
+    public func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         return Observable.create({ (observer) -> Disposable in
             let path = self.pathForKey(key)
             let previousSize = self.sizeForFileAtPath(path)

--- a/Sources/Caches/DiskCache.swift
+++ b/Sources/Caches/DiskCache.swift
@@ -17,7 +17,7 @@ public enum DrosteDiskError: Error {
     case diskSaveFailed
 }
 
-public class DiskCache<K, V>: Cache where K: StringConvertible, V: NSCoding {
+public class DiskCache<K, V>: Cache, ExpirableCache where K: StringConvertible, V: NSCoding {
     public typealias Key = K
     public typealias Value = V
     

--- a/Sources/Caches/RamCache.swift
+++ b/Sources/Caches/RamCache.swift
@@ -10,33 +10,11 @@ import Foundation
 import RxSwift
 
 public class RamCache<K, V>: ExpirableCache where K: Hashable {
-    
+
     public typealias Key = K
     public typealias Value = V
     
     public init() {}
-    
-    public func set(_ value: V, for key: K) -> Observable<Void> {
-        return setData(value, for: key)
-    }
-    
-    public func get(_ key: K) -> Observable<V?> {
-        return getData(key)
-            .map({ (value: V?) -> V? in
-                return value
-            })
-    }
-    
-    public func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
-        return getData(key)
-            .map({ (value: CacheExpirableDTO?) -> CacheExpirableDTO? in
-                return value
-            })
-    }
-    
-    public func _setExpirableDTO(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
-        return setData(value, for: key)
-    }
     
     public func clear() {
         storage = [:]
@@ -45,11 +23,11 @@ public class RamCache<K, V>: ExpirableCache where K: Hashable {
     //MARK: - Fetching
     private var storage: [K: Any] = [:]
     
-    private func getData<ValueType>(_ key: K) -> Observable<ValueType?> {
-        return Observable.just(storage[key] as? ValueType)
+    public func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+        return Observable.just(storage[key] as? GenericValueType)
     }
     
-    private func setData(_ value: Any, for key: K) -> Observable<Void> {
+    public func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         return Observable.just((key, value))
             .flatMap { [weak self] (pair) -> Observable<Void> in
                 guard let strongSelf = self else {

--- a/Sources/Caches/RamCache.swift
+++ b/Sources/Caches/RamCache.swift
@@ -23,11 +23,11 @@ public class RamCache<K, V>: ExpirableCache where K: Hashable {
     //MARK: - Fetching
     private var storage: [K: Any] = [:]
     
-    public func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+    public func _getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
         return Observable.just(storage[key] as? GenericValueType)
     }
     
-    public func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
+    public func _setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         return Observable.just((key, value))
             .flatMap { [weak self] (pair) -> Observable<Void> in
                 guard let strongSelf = self else {

--- a/Tests/CacheFake.swift
+++ b/Tests/CacheFake.swift
@@ -13,33 +13,27 @@ import Droste
 
 class CacheFake<K, V>: Cache, ExpirableCache {
     
-    func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
-        return Observable.empty()
-    }
-    
-    func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
-        return Observable.empty()
-    }
-    
-
     typealias Key = K
     typealias Value = V
 
-    var cacheDTORequest: PublishSubject<CacheExpirableDTO?>!
+    var cacheDTORequest: PublishSubject<Any?>!
     var numberOfTimesCalledCacheDTOGet = 0//CacheDTO
     var didCallExpirableDTOGetWithKey: K?
-    func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
+    
+    func _getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
         numberOfTimesCalledCacheDTOGet += 1
         cacheDTORequest = PublishSubject()
         queueUsedForTheLastCall = currentQueueSpecific()
         didCallExpirableDTOGetWithKey = key
-        return cacheDTORequest.asObservable()
+        return cacheDTORequest.map({ $0 as? GenericValueType })
     }
+
     
     var numberOfTimesCalledCacheDTOSet = 0//CacheDTO
     var didCalledCacheDTOSetWithKey: K?
-    var didCalledCacheDTOSetWithValue: CacheExpirableDTO?
-    func _setExpirableDTO(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
+    var didCalledCacheDTOSetWithValue: Any?
+    
+    func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         numberOfTimesCalledCacheDTOSet += 1
         didCalledCacheDTOSetWithKey = key
         didCalledCacheDTOSetWithValue = value

--- a/Tests/CacheFake.swift
+++ b/Tests/CacheFake.swift
@@ -10,11 +10,34 @@ import Foundation
 import RxSwift
 import Droste
 
-class CacheFake<K, V>: Cache {
+
+class CacheFake<K, V>: Cache, ExpirableCache {
 
     typealias Key = K
     typealias Value = V
 
+    var cacheDTORequest: PublishSubject<CacheExpirableDTO?>!
+    var numberOfTimesCalledCacheDTOGet = 0//CacheDTO
+    var didCallExpirableDTOGetWithKey: K?
+    func _getExpirableDTO(_ key: K) -> Observable<CacheExpirableDTO?> {
+        numberOfTimesCalledCacheDTOGet += 1
+        cacheDTORequest = PublishSubject()
+        queueUsedForTheLastCall = currentQueueSpecific()
+        didCallExpirableDTOGetWithKey = key
+        return cacheDTORequest.asObservable()
+    }
+    
+    var numberOfTimesCalledCacheDTOSet = 0//CacheDTO
+    var didCalledCacheDTOSetWithKey: K?
+    var didCalledCacheDTOSetWithValue: CacheExpirableDTO?
+    func _setExpirableDTO(_ value: CacheExpirableDTO, for key: K) -> Observable<Void> {
+        numberOfTimesCalledCacheDTOSet += 1
+        didCalledCacheDTOSetWithKey = key
+        didCalledCacheDTOSetWithValue = value
+        queueUsedForTheLastCall = currentQueueSpecific()
+        return Observable.just(())
+    }
+    
     var queueUsedForTheLastCall: UnsafeMutableRawPointer!
 
     var request: PublishSubject<V?>!

--- a/Tests/CacheFake.swift
+++ b/Tests/CacheFake.swift
@@ -20,7 +20,7 @@ class CacheFake<K, V>: Cache, ExpirableCache {
     var numberOfTimesCalledGenericDataGet = 0//CacheDTO
     var didCallGenericDataGetWithKey: K?
     
-    func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+    func _getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
         numberOfTimesCalledGenericDataGet += 1
         genericDataRequest = PublishSubject()
         queueUsedForTheLastCall = currentQueueSpecific()
@@ -33,7 +33,7 @@ class CacheFake<K, V>: Cache, ExpirableCache {
     var didCalledGenericDataSetWithKey: K?
     var didCalledGenericDataSetWithValue: Any?
     
-    func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
+    func _setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
         numberOfTimesCalledGenericDataSet += 1
         didCalledGenericDataSetWithKey = key
         didCalledGenericDataSetWithValue = value

--- a/Tests/CacheFake.swift
+++ b/Tests/CacheFake.swift
@@ -12,6 +12,15 @@ import Droste
 
 
 class CacheFake<K, V>: Cache, ExpirableCache {
+    
+    func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+        return Observable.empty()
+    }
+    
+    func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
+        return Observable.empty()
+    }
+    
 
     typealias Key = K
     typealias Value = V

--- a/Tests/CacheFake.swift
+++ b/Tests/CacheFake.swift
@@ -16,27 +16,27 @@ class CacheFake<K, V>: Cache, ExpirableCache {
     typealias Key = K
     typealias Value = V
 
-    var cacheDTORequest: PublishSubject<Any?>!
-    var numberOfTimesCalledCacheDTOGet = 0//CacheDTO
-    var didCallExpirableDTOGetWithKey: K?
+    var genericDataRequest: PublishSubject<Any?>!
+    var numberOfTimesCalledGenericDataGet = 0//CacheDTO
+    var didCallGenericDataGetWithKey: K?
     
-    func _getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
-        numberOfTimesCalledCacheDTOGet += 1
-        cacheDTORequest = PublishSubject()
+    func getData<GenericValueType>(_ key: K) -> Observable<GenericValueType?> {
+        numberOfTimesCalledGenericDataGet += 1
+        genericDataRequest = PublishSubject()
         queueUsedForTheLastCall = currentQueueSpecific()
-        didCallExpirableDTOGetWithKey = key
-        return cacheDTORequest.map({ $0 as? GenericValueType })
+        didCallGenericDataGetWithKey = key
+        return genericDataRequest.map({ $0 as? GenericValueType })
     }
 
     
-    var numberOfTimesCalledCacheDTOSet = 0//CacheDTO
-    var didCalledCacheDTOSetWithKey: K?
-    var didCalledCacheDTOSetWithValue: Any?
+    var numberOfTimesCalledGenericDataSet = 0
+    var didCalledGenericDataSetWithKey: K?
+    var didCalledGenericDataSetWithValue: Any?
     
     func setData<GenericValueType>(_ value: GenericValueType, for key: K) -> Observable<Void> {
-        numberOfTimesCalledCacheDTOSet += 1
-        didCalledCacheDTOSetWithKey = key
-        didCalledCacheDTOSetWithValue = value
+        numberOfTimesCalledGenericDataSet += 1
+        didCalledGenericDataSetWithKey = key
+        didCalledGenericDataSetWithValue = value
         queueUsedForTheLastCall = currentQueueSpecific()
         return Observable.just(())
     }

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -1,0 +1,10 @@
+//
+//  ExpireTests.swift
+//  Droste
+//
+//  Created by George Tsifrikas on 09/12/2017.
+//
+
+import Foundation
+
+

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -117,15 +117,16 @@ class ExpireTests: QuickSpec {
                 }
                 
                 context("when calling set", {
+                    var dateSet: Date!
                     beforeEach {
+                        dateSet = Date()
                         _ = sut.set("Hello World", for: 1).subscribe()
                     }
                     
                     it("should create the correct CacheExpirableDTO", closure: {
                         let createdDTO = cache.didCalledGenericDataSetWithValue as? CacheExpirableDTO
                         expect(createdDTO?.value as? String).to(equal("Hello World"))
-                        expect(Int(createdDTO!.expiryDate.timeIntervalSinceNow))
-                            .to(equal(Int(Date(timeIntervalSinceNow: 10).timeIntervalSinceNow)))
+                        expect(Int(createdDTO!.expiryDate.timeIntervalSince(dateSet))).to(equal(10))
                     })
                 })
                 

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -37,7 +37,7 @@ class ExpireTests: QuickSpec {
                     }
                     
                     it("should create the correct CacheExpirableDTO", closure: {
-                        let createdDTO = cache.didCalledCacheDTOSetWithValue
+                        let createdDTO = cache.didCalledCacheDTOSetWithValue as? CacheExpirableDTO
                         expect(createdDTO?.value as? String).to(equal("Hello World"))
                         expect(createdDTO?.expiryDate).to(equal(Date.distantFuture))
                     })
@@ -122,7 +122,7 @@ class ExpireTests: QuickSpec {
                     }
                     
                     it("should create the correct CacheExpirableDTO", closure: {
-                        let createdDTO = cache.didCalledCacheDTOSetWithValue
+                        let createdDTO = cache.didCalledCacheDTOSetWithValue as? CacheExpirableDTO
                         expect(createdDTO?.value as? String).to(equal("Hello World"))
                         expect(Int(createdDTO!.expiryDate.timeIntervalSinceNow))
                             .to(equal(Int(Date(timeIntervalSinceNow: 10).timeIntervalSinceNow)))

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -14,7 +14,7 @@ import RxTest
 
 class ExpireTests: QuickSpec {
     override func spec() {
-        describe("The expires operator") {
+        describe("Cache using expires operator") {
             var cache: CacheFake<Int, String>!
             var scheduler: TestScheduler!
             var cacheObserver: TestableObserver<String>!

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -25,10 +25,10 @@ class ExpireTests: QuickSpec {
                 cacheObserver = scheduler.createObserver(String.self)
             }
             
-            context("when does not expires", {
+            context("when does not expires in the near future", {
                 beforeEach {
                     cache = CacheFake()
-                    sut = cache.expires(at: .never)
+                    sut = cache.expires(at: .date(.distantFuture))
                 }
                 
                 context("when calling set", {

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -6,5 +6,173 @@
 //
 
 import Foundation
+import Nimble
+import Quick
+import RxSwift
+import RxTest
+@testable import Droste
 
-
+class ExpireTests: QuickSpec {
+    override func spec() {
+        describe("The expires operator") {
+            var cache: CacheFake<Int, String>!
+            var scheduler: TestScheduler!
+            var cacheObserver: TestableObserver<String>!
+            var sut: CompositeCache<Int, String>!
+            
+            beforeEach {
+                scheduler = TestScheduler(initialClock: 0)
+                cacheObserver = scheduler.createObserver(String.self)
+            }
+            
+            context("when does not expires", {
+                beforeEach {
+                    cache = CacheFake()
+                    sut = cache.expires(at: .never)
+                }
+                
+                context("when calling set", {
+                    beforeEach {
+                        _ = sut.set("Hello World", for: 1).subscribe()
+                    }
+                    
+                    it("should create the correct CacheExpirableDTO", closure: {
+                        let createdDTO = cache.didCalledCacheDTOSetWithValue
+                        expect(createdDTO?.value as? String).to(equal("Hello World"))
+                        expect(createdDTO?.expiryDate).to(equal(Date.distantFuture))
+                    })
+                })
+                
+                context("when calling get", {
+                    context("when value is malformed") {
+                        beforeEach {
+                            scheduler.scheduleAt(0) {
+                                _ = sut.get(1).subscribe(cacheObserver)
+                            }
+                            
+                            scheduler.scheduleAt(1) {
+                                let cacheExpirableDTO = CacheExpirableDTO(value: 12345 as AnyObject, expiryDate: Date.distantFuture)
+                                cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                            }
+                            scheduler.start()
+                        }
+                        
+                        it("should invoke _getExpirableDTO of cache", closure: {
+                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        })
+                        
+                        it("should return nil", closure: {
+                            expect(cacheObserver.events.first?.value.element).to(beNil())
+                        })
+                    }
+                    context("when value exists", {
+                        beforeEach {
+                            scheduler.scheduleAt(0) {
+                                _ = sut.get(1).subscribe(cacheObserver)
+                            }
+                            
+                            scheduler.scheduleAt(1) {
+                                let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date.distantFuture)
+                                cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                            }
+                            scheduler.start()
+                        }
+                        
+                        it("should invoke _getExpirableDTO of cache", closure: {
+                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        })
+                        
+                        it("should return the correct value from the DTO", closure: {
+                            expect(cacheObserver.events.first?.value.element).to(equal("Hello World"))
+                        })
+                    })
+                    
+                    context("when value does not exists", {
+                        beforeEach {
+                            scheduler.scheduleAt(0) {
+                                _ = sut.get(1).subscribe(cacheObserver)
+                            }
+                            
+                            scheduler.scheduleAt(1) {
+                                cache.cacheDTORequest.on(.next(nil))
+                            }
+                            scheduler.start()
+                        }
+                        
+                        it("should invoke _getExpirableDTO of cache", closure: {
+                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        })
+                        
+                        it("should return the correct value from the DTO", closure: {
+                            expect(cacheObserver.events.first?.value.element).to(beNil())
+                        })
+                    })
+                })
+            })
+            
+            context("when does expires", {
+                beforeEach {
+                    cache = CacheFake()
+                    sut = cache.expires(at: .seconds(10))
+                }
+                
+                context("when calling set", {
+                    beforeEach {
+                        _ = sut.set("Hello World", for: 1).subscribe()
+                    }
+                    
+                    it("should create the correct CacheExpirableDTO", closure: {
+                        let createdDTO = cache.didCalledCacheDTOSetWithValue
+                        expect(createdDTO?.value as? String).to(equal("Hello World"))
+                        expect(Int(createdDTO!.expiryDate.timeIntervalSinceNow))
+                            .to(equal(Int(Date(timeIntervalSinceNow: 10).timeIntervalSinceNow)))
+                    })
+                })
+                
+                context("when calling get before expiry", {
+                    beforeEach {
+                        scheduler.scheduleAt(0) {
+                            _ = sut.get(1).subscribe(cacheObserver)
+                        }
+                        
+                        scheduler.scheduleAt(1) {
+                            let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date(timeIntervalSinceNow: 1))
+                            cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                        }
+                        scheduler.start()
+                    }
+                    
+                    it("should invoke _getExpirableDTO of cache", closure: {
+                        expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                    })
+                    
+                    it("should return the correct value from the DTO", closure: {
+                        expect(cacheObserver.events.first?.value.element).to(equal("Hello World"))
+                    })
+                })
+                
+                context("when calling get after expiry", {
+                    beforeEach {
+                        scheduler.scheduleAt(0) {
+                            _ = sut.get(1).subscribe(cacheObserver)
+                        }
+                        
+                        scheduler.scheduleAt(1) {
+                            let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date(timeIntervalSinceNow: -1))
+                            cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                        }
+                        scheduler.start()
+                    }
+                    
+                    it("should invoke _getExpirableDTO of cache", closure: {
+                        expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                    })
+                    
+                    it("should return the correct value from the DTO", closure: {
+                        expect(cacheObserver.events.first?.value.element).to(beNil())
+                    })
+                })
+            })
+        }
+    }
+}

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -21,13 +21,13 @@ class ExpireTests: QuickSpec {
             var sut: CompositeCache<Int, String>!
             
             beforeEach {
+                cache = CacheFake()
                 scheduler = TestScheduler(initialClock: 0)
                 cacheObserver = scheduler.createObserver(String.self)
             }
             
             context("when does not expires in the near future", {
                 beforeEach {
-                    cache = CacheFake()
                     sut = cache.expires(at: .date(.distantFuture))
                 }
                 
@@ -158,7 +158,7 @@ class ExpireTests: QuickSpec {
                         }
                         
                         scheduler.scheduleAt(1) {
-                            let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date(timeIntervalSinceNow: -1))
+                            let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World Expired" as AnyObject, expiryDate: Date(timeIntervalSinceNow: -1))
                             cache.genericDataRequest.on(.next(cacheExpirableDTO))
                         }
                         scheduler.start()
@@ -169,7 +169,7 @@ class ExpireTests: QuickSpec {
                     })
                     
                     it("should return the correct value from the DTO", closure: {
-                        expect(cacheObserver.events.first?.value.element).to(beNil())
+                        expect(cacheObserver.events.first!.value.element).to(beNil())
                     })
                 })
             })

--- a/Tests/ExpireTests.swift
+++ b/Tests/ExpireTests.swift
@@ -37,7 +37,7 @@ class ExpireTests: QuickSpec {
                     }
                     
                     it("should create the correct CacheExpirableDTO", closure: {
-                        let createdDTO = cache.didCalledCacheDTOSetWithValue as? CacheExpirableDTO
+                        let createdDTO = cache.didCalledGenericDataSetWithValue as? CacheExpirableDTO
                         expect(createdDTO?.value as? String).to(equal("Hello World"))
                         expect(createdDTO?.expiryDate).to(equal(Date.distantFuture))
                     })
@@ -52,13 +52,13 @@ class ExpireTests: QuickSpec {
                             
                             scheduler.scheduleAt(1) {
                                 let cacheExpirableDTO = CacheExpirableDTO(value: 12345 as AnyObject, expiryDate: Date.distantFuture)
-                                cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                                cache.genericDataRequest.on(.next(cacheExpirableDTO))
                             }
                             scheduler.start()
                         }
                         
-                        it("should invoke _getExpirableDTO of cache", closure: {
-                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        it("should invoke getData of cache", closure: {
+                            expect(cache.numberOfTimesCalledGenericDataGet).to(equal(1))
                         })
                         
                         it("should return nil", closure: {
@@ -73,13 +73,13 @@ class ExpireTests: QuickSpec {
                             
                             scheduler.scheduleAt(1) {
                                 let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date.distantFuture)
-                                cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                                cache.genericDataRequest.on(.next(cacheExpirableDTO))
                             }
                             scheduler.start()
                         }
                         
-                        it("should invoke _getExpirableDTO of cache", closure: {
-                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        it("should invoke getData of cache", closure: {
+                            expect(cache.numberOfTimesCalledGenericDataGet).to(equal(1))
                         })
                         
                         it("should return the correct value from the DTO", closure: {
@@ -94,13 +94,13 @@ class ExpireTests: QuickSpec {
                             }
                             
                             scheduler.scheduleAt(1) {
-                                cache.cacheDTORequest.on(.next(nil))
+                                cache.genericDataRequest.on(.next(nil))
                             }
                             scheduler.start()
                         }
                         
-                        it("should invoke _getExpirableDTO of cache", closure: {
-                            expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                        it("should invoke getData of cache", closure: {
+                            expect(cache.numberOfTimesCalledGenericDataGet).to(equal(1))
                         })
                         
                         it("should return the correct value from the DTO", closure: {
@@ -122,7 +122,7 @@ class ExpireTests: QuickSpec {
                     }
                     
                     it("should create the correct CacheExpirableDTO", closure: {
-                        let createdDTO = cache.didCalledCacheDTOSetWithValue as? CacheExpirableDTO
+                        let createdDTO = cache.didCalledGenericDataSetWithValue as? CacheExpirableDTO
                         expect(createdDTO?.value as? String).to(equal("Hello World"))
                         expect(Int(createdDTO!.expiryDate.timeIntervalSinceNow))
                             .to(equal(Int(Date(timeIntervalSinceNow: 10).timeIntervalSinceNow)))
@@ -137,13 +137,13 @@ class ExpireTests: QuickSpec {
                         
                         scheduler.scheduleAt(1) {
                             let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date(timeIntervalSinceNow: 1))
-                            cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                            cache.genericDataRequest.on(.next(cacheExpirableDTO))
                         }
                         scheduler.start()
                     }
                     
-                    it("should invoke _getExpirableDTO of cache", closure: {
-                        expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                    it("should invoke getData of cache", closure: {
+                        expect(cache.numberOfTimesCalledGenericDataGet).to(equal(1))
                     })
                     
                     it("should return the correct value from the DTO", closure: {
@@ -159,13 +159,13 @@ class ExpireTests: QuickSpec {
                         
                         scheduler.scheduleAt(1) {
                             let cacheExpirableDTO = CacheExpirableDTO(value: "Hello World" as AnyObject, expiryDate: Date(timeIntervalSinceNow: -1))
-                            cache.cacheDTORequest.on(.next(cacheExpirableDTO))
+                            cache.genericDataRequest.on(.next(cacheExpirableDTO))
                         }
                         scheduler.start()
                     }
                     
-                    it("should invoke _getExpirableDTO of cache", closure: {
-                        expect(cache.numberOfTimesCalledCacheDTOGet).to(equal(1))
+                    it("should invoke getData of cache", closure: {
+                        expect(cache.numberOfTimesCalledGenericDataGet).to(equal(1))
                     })
                     
                     it("should return the correct value from the DTO", closure: {


### PR DESCRIPTION
# Caches with expiry
### What changed
Create ExpirableCache which add supports in expiry support in caches. The way is done is by declaring two new functions:
`_getData<GenericValueType>(_ key: Self.Key) -> Observable<GenericValueType?>`
`_setData<GenericValueType>(_ value: GenericValueType, for key: Self.Key) -> Observable<Void>`

These functions essentially replace the following:
`func get(_ key: Key) -> Observable<Value?>`
`func set(_ value: Value, for key: Key) -> Observable<Void>`

.. and allow to use them to store and retrieve unknown type of elements.
**These new function are intended only for internal use**

Normal `get` and `set` are provided using protocol extensions on `ExpirableCache`.

### How
In each cache that supports `ExpirableCache` the only change was to replace the declarations as described above. Everything else is on extensions on`ExpirableCache` protocol, so support for ExpiryCache was quite strait-forward.
No calculations when an object is expired required inside each cache implementation.



Changes proposed in this request:
* Introduce `ExpiryCache` protocol
* Conform `RamCache` and `DiskCache` to it
* Make shared caches to use (optional) an expiry
* Updated README
* Write tests for `ExpiryCache`


